### PR TITLE
fix(django_app): persist org variables for webhook-triggered sessions

### DIFF
--- a/src/django_app/tables/services/redis_pubsub.py
+++ b/src/django_app/tables/services/redis_pubsub.py
@@ -75,6 +75,12 @@ class RedisPubSub:
                     session.status = data["status"]
                     session.status_data = data.get("status_data", {})
                     session.save()
+
+                    if session.status in [
+                        Session.SessionStatus.END,
+                        Session.SessionStatus.ERROR,
+                    ]:
+                        self._save_organization_variables(session=session, data=data)
         except Exception as e:
             logger.error(f"Error handling session_status message: {e}")
 

--- a/src/django_app/tables/services/webhook_trigger_service.py
+++ b/src/django_app/tables/services/webhook_trigger_service.py
@@ -1,5 +1,5 @@
 from tables.services.session_manager_service import SessionManagerService
-from tables.models.graph_models import WebhookTriggerNode
+from tables.models.graph_models import WebhookTriggerNode, GraphOrganization
 from utils.singleton_meta import SingletonMeta
 
 
@@ -13,8 +13,14 @@ class WebhookTriggerService(metaclass=SingletonMeta):
         )
 
         for webhook_trigger_node in webhook_trigger_node_list:
+            graph_organization = GraphOrganization.objects.filter(
+                graph=webhook_trigger_node.graph
+            ).first()
+            variables: dict = {"trigger_payload": payload}
+            if graph_organization:
+                variables.update(graph_organization.persistent_variables)
             self.session_manager_service.run_session(
                 graph_id=webhook_trigger_node.graph.pk,
-                variables={"trigger_payload": payload},
+                variables=variables,
                 entrypoint=webhook_trigger_node.node_name,
             )


### PR DESCRIPTION
### Problem
Webhook-triggered runs correctly produced updated state  in the session output, but those values were not persisted into GraphOrganization.persistent_variables. As a result, subsequent webhook invocations started with empty org-level state even though the previous session had the correct variables.

### Root cause
Org/user persistence write-back logic existed (RedisPubSub._save_organization_variables) but was never invoked on session completion.
Webhook-triggered sessions started with only trigger_payload and did not merge org persistent variables into the initial variables.
### Changes

- **Load org-level persisted variables on webhook trigger**
WebhookTriggerService now merges GraphOrganization.persistent_variables into the variables passed to run_session (no username required).

- **Persist org/user variables on session completion**
RedisPubSub.session_status_handler now calls _save_organization_variables(...) when a session transitions to END or ERROR, updating:
     - GraphOrganization.persistent_variables
     - GraphOrganizationUser.persistent_variables (if session.graph_user is set)

### Files changed
src/django_app/tables/services/webhook_trigger_service.py
src/django_app/tables/services/redis_pubsub.py