### PR TITLE
Update .gitignore to exclude Claude Code files

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,7 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "Bash(make dev:*)"
-    ]
-  }
-}

--- a/.gitignore
+++ b/.gitignore
@@ -261,3 +261,8 @@ knowledge/graph_data/
 *.crt!
 dev/dev.config.json
 dev/dev.env
+
+# AI Coding Assistant Configs
+.claude/
+CLAUDE.md
+CLAUDE.local.md


### PR DESCRIPTION
This PR updates the .gitignore file to ignore Claude Code related files and directories, preventing them from being accidentally committed to the repository.
