### PR TITLE
fix(EST-2615-BE): fix bug with installing library thinc on macos

### DIFF
--- a/src/docker-compose.yaml
+++ b/src/docker-compose.yaml
@@ -291,9 +291,12 @@ services:
 
   knowledge:
     image: knowledge
+    platform: linux/amd64
     build:
       context: .
       dockerfile: ./knowledge/Dockerfile.knowledge
+      platforms:
+        - linux/amd64
     container_name: knowledge
     environment:
       <<: *common_env

--- a/src/knowledge/Dockerfile.knowledge
+++ b/src/knowledge/Dockerfile.knowledge
@@ -1,5 +1,7 @@
 # --- Stage 1: Builder ---
-FROM python:3.12.10-slim@sha256:fd95fa221297a88e1cf49c55ec1828edd7c5a428187e67b5d1805692d11588db AS builder
+# Pinned to linux/amd64 so Apple Silicon hosts use Rosetta emulation and
+# consume prebuilt x86_64 wheels (thinc/blis/spacy have no linux/arm64 wheels).
+FROM --platform=linux/amd64 python:3.12.10-slim@sha256:fd95fa221297a88e1cf49c55ec1828edd7c5a428187e67b5d1805692d11588db AS builder
 
 ENV POETRY_VIRTUALENVS_IN_PROJECT=true \
     POETRY_NO_INTERACTION=1 \
@@ -37,7 +39,7 @@ COPY ./knowledge /app/src/knowledge
 COPY ./shared /app/src/shared
 
 # --- Stage 2: Runtime ---
-FROM python:3.12.10-slim@sha256:fd95fa221297a88e1cf49c55ec1828edd7c5a428187e67b5d1805692d11588db AS runtime
+FROM --platform=linux/amd64 python:3.12.10-slim@sha256:fd95fa221297a88e1cf49c55ec1828edd7c5a428187e67b5d1805692d11588db AS runtime
 
 # libpq-dev are required for psycopg2 https://www.psycopg.org/docs/install.html
 RUN apt-get update && apt-get install -y libpq-dev \


### PR DESCRIPTION
  Environment: macOS (Apple Silicon / M-series), Docker Desktop, linux/arm64 default
  Affected service: knowledge
  Affected dep: graphrag → spacy → thinc==8.3.4

  Steps to reproduce:
    docker compose up --build knowledge

  Expected: container builds successfully
  Actual: poetry install fails while building thinc from source — thinc 8.3.4
          ships no manylinux_aarch64 wheel, falls back to sdist, BLIS compile
          errors out under the slim image's toolchain.

  Root cause: No prebuilt linux/arm64 wheel for thinc==8.3.4 (and transitive
  spacy C-extension deps). Source build requires g++/gfortran/BLIS toolchain
  not present in the slim base.

  Fix: Pin knowledge container to linux/amd64 so Apple Silicon uses Rosetta
  emulation and installs prebuilt x86_64 wheels. No lockfile changes required.
  Windows/Linux amd64 unaffected.