### PR TITLE
Fix/est 2615 build knowledge macos 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -271,6 +271,7 @@ CLAUDE.md
 CLAUDE.local.md
 !prod/prod.env.manifest
 .claude/settings.local.json
+/personal_files
 
 # Self — local gitignore tweaks should not be tracked
 .gitignore

--- a/src/knowledge/Dockerfile.knowledge
+++ b/src/knowledge/Dockerfile.knowledge
@@ -14,6 +14,7 @@ WORKDIR /app/src
 RUN apt-get update && apt-get install -y \
     libpq-dev \
     gcc \
+    g++ \
     python3-dev \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Added g++ to the builder stage only (runtime stage stays slim — no compilers shipped). This lets thinc's C++ extensions compile natively on arm64, avoiding Rosetta (from previous PR: https://github.com/EpicStaff/EpicStaff/pull/455)