### PR TITLE
fix(EST-2672-BE): resolve llm tags import

### DIFF
--- a/src/django_app/tables/import_export/serializers/llm_models.py
+++ b/src/django_app/tables/import_export/serializers/llm_models.py
@@ -2,7 +2,9 @@ from rest_framework import serializers
 
 from tables.models import (
     LLMModel,
+    LLMModelTag,
     EmbeddingModel,
+    EmbeddingModelTag,
     RealtimeModel,
     RealtimeTranscriptionModel,
     Provider,
@@ -34,6 +36,9 @@ class LLMModelImportSerializer(BaseModelImportSerializer):
         source="llm_provider",
         write_only=True,
     )
+    tags = serializers.PrimaryKeyRelatedField(
+        queryset=LLMModelTag.objects.all(), many=True
+    )
 
     class Meta:
         model = LLMModel
@@ -46,6 +51,9 @@ class EmbeddingModelImportSerializer(BaseModelImportSerializer):
         queryset=Provider.objects.all(),
         source="embedding_provider",
         write_only=True,
+    )
+    tags = serializers.PrimaryKeyRelatedField(
+        queryset=EmbeddingModelTag.objects.all(), many=True
     )
 
     class Meta:

--- a/src/django_app/tables/import_export/strategies/configs.py
+++ b/src/django_app/tables/import_export/strategies/configs.py
@@ -5,8 +5,6 @@ from tables.models import (
     EmbeddingConfig,
     RealtimeConfig,
     RealtimeTranscriptionConfig,
-    LLMModel,
-    EmbeddingModel,
     RealtimeModel,
     RealtimeTranscriptionModel,
 )
@@ -25,6 +23,7 @@ from tables.import_export.utils import ensure_unique_identifier, create_filters
 class BaseConfigStrategy(EntityImportExportStrategy):
     entity_type: EntityType
     model_entity_type: EntityType
+    tag_entity: EntityType | None = None
 
     config_model = None
     serializer_class = None
@@ -52,9 +51,19 @@ class BaseConfigStrategy(EntityImportExportStrategy):
         return {"id": instance.id, "name": instance.custom_name}
 
     def extract_dependencies_from_instance(self, instance):
-        return {self.model_entity_type: [getattr(instance, self.model_fk_field).id]}
+        deps: dict[str, list[int]] = {
+            self.model_entity_type: [getattr(instance, self.model_fk_field).id]
+        }
 
-    def create_entity(self, data, id_mapper: IDMapper):
+        if self.tag_entity:
+            tag_ids = list(instance.tags.values_list("id", flat=True))
+
+            if tag_ids:
+                deps[self.tag_entity] = tag_ids
+
+        return deps
+
+    def create_entity(self, data, id_mapper: IDMapper, **kwargs):
         if "custom_name" in data:
             existing_names = self.config_model.objects.values_list(
                 "custom_name", flat=True
@@ -64,8 +73,19 @@ class BaseConfigStrategy(EntityImportExportStrategy):
                 existing_names=existing_names,
             )
 
+        old_tag_ids = data.pop("tags", [])
+        tag_overrides = {}
+
+        if self.tag_entity and old_tag_ids:
+            new_tag_ids = [
+                id_mapper.get_or_none(self.tag_entity, oid) for oid in old_tag_ids
+            ]
+            tag_overrides["tags"] = [nid for nid in new_tag_ids if nid is not None]
+
         resolved_fks = self.remap_foreign_keys(data, id_mapper)
-        serializer = self.serializer_class(data={**data, **resolved_fks})
+        serializer = self.serializer_class(
+            data={**data, **resolved_fks, **tag_overrides}
+        )
         serializer.is_valid(raise_exception=True)
         return serializer.save()
 
@@ -75,6 +95,7 @@ class BaseConfigStrategy(EntityImportExportStrategy):
     def find_existing(self, data, id_mapper):
         data_copy = deepcopy(data)
         data_copy.pop("id", None)
+        data_copy.pop("tags", None)
 
         fk_filters = self.resolve_fk_filters(data_copy, id_mapper)
         filters, null_filters = create_filters(data_copy)
@@ -104,6 +125,7 @@ class BaseConfigStrategy(EntityImportExportStrategy):
 class LLMConfigStrategy(BaseConfigStrategy):
     entity_type = EntityType.LLM_CONFIG
     model_entity_type = EntityType.LLM_MODEL
+    tag_entity = EntityType.LLM_CONFIG_TAG
     config_model = LLMConfig
     serializer_class = LLMConfigImportSerializer
 

--- a/src/django_app/tables/import_export/strategies/llm_models.py
+++ b/src/django_app/tables/import_export/strategies/llm_models.py
@@ -49,11 +49,11 @@ class BaseProviderModelStrategy(EntityImportExportStrategy):
                 existing_names=existing_names,
             )
 
-        tags = self._get_tags(data, id_mapper)
+        tags_ids = self._get_tags(data, id_mapper)
         provider_name = data.pop("provider_name")
         provider = Provider.objects.get(name=provider_name)
         serializer = self.serializer_class(
-            data={**data, "provider_id": provider.id, "tags": tags}
+            data={**data, "provider_id": provider.id, "tags": tags_ids}
         )
         serializer.is_valid(raise_exception=True)
         return serializer.save()


### PR DESCRIPTION
This PR propose a fix for error when importing files with llm model tags. There were 2 issues:

- find_existing() was trying to use tags as filter and failed
- create_entity() for LLMConfigs was not getting proper tag ids to set them in m2m