### PR TITLE
fix(EST-2923-FE): skip node panel save emit when panel is not dirty

### DIFF
--- a/frontend/src/app/visual-programming/components/node-panels/node-panel-shell/node-panel-shell.component.ts
+++ b/frontend/src/app/visual-programming/components/node-panels/node-panel-shell/node-panel-shell.component.ts
@@ -263,7 +263,11 @@ export class NodePanelShellComponent {
     }
 
     private saveSidePanel(): void {
-        if (this.panelInstance && typeof this.panelInstance.onSave === 'function') {
+        if (
+            this.panelInstance &&
+            typeof this.panelInstance.onSave === 'function' &&
+            this.panelInstanceSig()?.isDirty?.()
+        ) {
             const updatedNode = this.panelInstance.onSave();
             if (updatedNode) {
                 this.save.emit(updatedNode);
@@ -274,7 +278,11 @@ export class NodePanelShellComponent {
     }
 
     private performAutosave(): void {
-        if (this.panelInstance && typeof this.panelInstance.onSave === 'function') {
+        if (
+            this.panelInstance &&
+            typeof this.panelInstance.onSave === 'function' &&
+            this.panelInstanceSig()?.isDirty?.()
+        ) {
             const updatedNode = this.panelInstance.onSave();
             if (updatedNode) {
                 this.autosave.emit(updatedNode);


### PR DESCRIPTION
Closing or switching a node panel without edits no longer marks the flow as having unsaved changes. saveSidePanel and performAutosave now gate onSave/emit on the panel's isDirty signal, preventing a no-op round-trip through the form from producing a non-equivalent serialized node.