### PR TITLE
fix(EST-2614-BE): add upstream to nginx config for webhook microservice

### DIFF
--- a/src/docker-compose.yaml
+++ b/src/docker-compose.yaml
@@ -449,6 +449,7 @@ services:
       - DOMAIN_NAME=${DOMAIN_NAME}
       - SSL_ENABLE=${SSL_ENABLE}
       - FRONTEND_INTERNAL_PORT=80
+      - WEBHOOK_PORT=${WEBHOOK_PORT:-8051}
     volumes:
       - ./nginx/templates/default.conf.template:/etc/nginx/templates/default.conf.template
       - ./nginx/certs:/etc/nginx/certs:ro

--- a/src/nginx/templates/default.conf.template
+++ b/src/nginx/templates/default.conf.template
@@ -15,6 +15,10 @@ upstream realtime_server {
     server realtime:8050;
 }
 
+upstream webhook_server {
+    server webhook:${WEBHOOK_PORT};
+}
+
 server {
     listen 80;
     client_max_body_size 50M;
@@ -65,6 +69,16 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location ^~ /webhooks/ {
+        proxy_pass http://webhook_server;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $host;
     }
 
     location = /voice {


### PR DESCRIPTION
# What

Restore routing for the webhook microservice in nginx. Webhook triggers used by telegram and python nodes were unreachable from the outside — nginx had no upstream/location for the `webhook` service, so requests to `/webhooks/...` fell through to the frontend root, which only accepts GET and responded with 405 Method Not Allowed.

# How

- Added upstream `webhook_server` → `webhook:${WEBHOOK_PORT}` in `nginx/templates/default.conf.template`
- Added location `^~ /webhooks/` proxying to that upstream, with standard headers (`Host`, `X-Real-IP`, `X-Forwarded-For`, `X-Forwarded-Proto`, `X-Forwarded-Host`)
- Exposed `WEBHOOK_PORT` (default `8051`) to the nginx container via `docker-compose.yaml`

# Related
- [EST-2614 - Unable to use telegram/python nodes (auth) | BE](https://hys-enterprise.atlassian.net/browse/EST-2614)