### PR TITLE
feat(EST-2): add flow presence walking skeleton (collab WS + particip…

### DIFF
--- a/frontend/src/app/pages/flows-page/components/flow-visual-programming/flow-visual-programming.component.html
+++ b/frontend/src/app/pages/flows-page/components/flow-visual-programming/flow-visual-programming.component.html
@@ -18,6 +18,9 @@
     ></app-flow-header>
 
     <div class="body">
+        @if (presenceCount() > 1) {
+            <span class="presence-indicator">{{ presenceCount() }} in this flow</span>
+        }
         @if (restoreWarnings().length > 0) {
             <button
                 class="restore-warning-btn"

--- a/frontend/src/app/pages/flows-page/components/flow-visual-programming/flow-visual-programming.component.scss
+++ b/frontend/src/app/pages/flows-page/components/flow-visual-programming/flow-visual-programming.component.scss
@@ -27,6 +27,24 @@ app-flow-header {
     }
 }
 
+.presence-indicator {
+    position: absolute;
+    top: 0.75rem;
+    right: 1rem;
+    z-index: 10;
+    display: inline-flex;
+    align-items: center;
+    padding: 0.25rem 0.625rem;
+    border-radius: 1rem;
+    font-size: 0.75rem;
+    font-weight: 500;
+    color: var(--color-text-secondary);
+    background: var(--color-divider-subtle);
+    border: 1px solid var(--color-divider-regular);
+    pointer-events: none;
+    user-select: none;
+}
+
 .restore-warning-btn {
     position: absolute;
     bottom: 3.5rem;

--- a/frontend/src/app/pages/flows-page/components/flow-visual-programming/flow-visual-programming.component.ts
+++ b/frontend/src/app/pages/flows-page/components/flow-visual-programming/flow-visual-programming.component.ts
@@ -54,6 +54,7 @@ import { FlowsStorageService } from '../../../../features/flows/services/flows-s
 import { RunGraphService } from '../../../../features/flows/services/run-graph-session.service';
 import { FlowMessagesPanelComponent } from '../../../../pages/running-graph/components/flow-messages-panel/flow-messages-panel.component';
 import { RunSessionSSEService } from '../../../../pages/running-graph/services/graph-session-sse.service';
+import { CollaborationPresenceService } from '../../../../services/collaboration/collaboration-presence.service';
 import { ConfigService } from '../../../../services/config/config.service';
 import { ToastService } from '../../../../services/notifications/toast.service';
 import { AppSvgIconComponent } from '../../../../shared/components/app-svg-icon/app-svg-icon.component';
@@ -148,6 +149,10 @@ export class FlowVisualProgrammingComponent implements OnInit, OnDestroy, CanCom
         return this.graphState()!;
     }
 
+    public readonly presenceCount = computed(() => this.collaborationPresenceService.participantCount());
+
+    private readonly collaborationPresenceService = inject(CollaborationPresenceService);
+
     constructor(
         private readonly route: ActivatedRoute,
         private readonly router: Router,
@@ -187,6 +192,7 @@ export class FlowVisualProgrammingComponent implements OnInit, OnDestroy, CanCom
             const warnings = this.createGraphWarningService.readPending();
             if (warnings.length) this.restoreWarnings.set(warnings);
             this.fetchGraph(graphId);
+            this.collaborationPresenceService.connect(graphId);
         });
 
         this.sidePanelService.saveNodeRequest$
@@ -597,6 +603,7 @@ export class FlowVisualProgrammingComponent implements OnInit, OnDestroy, CanCom
     public ngOnDestroy(): void {
         this.flowUnsavedStateService.unregister();
         this.runSessionSSEService.stopStream();
+        this.collaborationPresenceService.disconnect();
     }
 
     private addStartNodeIfNeeded(flowModel: FlowModel): FlowModel {

--- a/frontend/src/app/services/collaboration/collab-message.model.ts
+++ b/frontend/src/app/services/collaboration/collab-message.model.ts
@@ -1,0 +1,7 @@
+export interface PresenceMessage {
+    type: 'presence';
+    flow_id: number;
+    count: number;
+}
+
+export type CollabConnectionState = 'disconnected' | 'connecting' | 'connected';

--- a/frontend/src/app/services/collaboration/collaboration-presence.service.ts
+++ b/frontend/src/app/services/collaboration/collaboration-presence.service.ts
@@ -1,0 +1,191 @@
+import { inject, Injectable, signal } from '@angular/core';
+
+import { AuthService } from '../auth/auth.service';
+import { ConfigService } from '../config/config.service';
+import { CollabConnectionState, PresenceMessage } from './collab-message.model';
+
+const RECONNECT_DELAY_MS = 3_000;
+
+@Injectable({ providedIn: 'root' })
+export class CollaborationPresenceService {
+    readonly participantCount = signal<number>(0);
+    readonly connectionState = signal<CollabConnectionState>('disconnected');
+
+    private readonly authService = inject(AuthService);
+    private readonly configService = inject(ConfigService);
+
+    private socket: WebSocket | null = null;
+    private connectedFlowId: number | null = null;
+    private intentionalClose = false;
+    private reconnectTimerId: ReturnType<typeof setTimeout> | null = null;
+
+    connect(flowId: number): void {
+        if (this.socket !== null) {
+            if (this.connectedFlowId === flowId) {
+                return;
+            }
+            this.disconnect();
+        }
+
+        this.openSocket(flowId);
+    }
+
+    disconnect(): void {
+        this.intentionalClose = true;
+        this.cancelPendingReconnect();
+        this.closeSocket();
+        this.participantCount.set(0);
+        this.connectionState.set('disconnected');
+        this.connectedFlowId = null;
+    }
+
+    private openSocket(flowId: number): void {
+        const url = this.buildWebSocketUrl(flowId);
+        if (url === null) {
+            return;
+        }
+
+        this.intentionalClose = false;
+        this.connectedFlowId = flowId;
+        this.connectionState.set('connecting');
+
+        const webSocket = new WebSocket(url);
+        this.socket = webSocket;
+
+        webSocket.onopen = (): void => {
+            if (this.socket === webSocket) {
+                this.connectionState.set('connected');
+            }
+        };
+
+        webSocket.onmessage = (event: MessageEvent): void => {
+            this.handleMessage(event);
+        };
+
+        webSocket.onclose = (): void => {
+            if (this.socket !== webSocket) {
+                return;
+            }
+            this.socket = null;
+
+            if (this.intentionalClose) {
+                return;
+            }
+
+            this.connectionState.set('disconnected');
+            this.scheduleReconnect(flowId);
+        };
+
+        webSocket.onerror = (): void => {
+            // The close event fires immediately after an error, so no additional
+            // state updates are needed here. The close handler drives recovery.
+        };
+    }
+
+    private handleMessage(event: MessageEvent): void {
+        let parsed: unknown;
+        try {
+            parsed = JSON.parse(event.data as string);
+        } catch {
+            return;
+        }
+
+        if (!isPresenceMessage(parsed)) {
+            return;
+        }
+
+        this.participantCount.set(parsed.count);
+    }
+
+    private scheduleReconnect(flowId: number): void {
+        this.cancelPendingReconnect();
+        this.reconnectTimerId = setTimeout(() => {
+            this.reconnectTimerId = null;
+            if (this.intentionalClose) {
+                return;
+            }
+            this.attemptReconnect(flowId);
+        }, RECONNECT_DELAY_MS);
+    }
+
+    private attemptReconnect(flowId: number): void {
+        const url = this.buildWebSocketUrl(flowId);
+        if (url === null) {
+            return;
+        }
+
+        this.connectedFlowId = flowId;
+        this.connectionState.set('connecting');
+
+        const webSocket = new WebSocket(url);
+        this.socket = webSocket;
+
+        webSocket.onopen = (): void => {
+            if (this.socket === webSocket) {
+                this.connectionState.set('connected');
+            }
+        };
+
+        webSocket.onmessage = (event: MessageEvent): void => {
+            this.handleMessage(event);
+        };
+
+        webSocket.onclose = (): void => {
+            if (this.socket !== webSocket) {
+                return;
+            }
+            this.socket = null;
+
+            if (!this.intentionalClose) {
+                // Reconnect attempt also failed — stay disconnected per spec.
+                this.connectionState.set('disconnected');
+                this.connectedFlowId = null;
+            }
+        };
+
+        webSocket.onerror = (): void => {
+            // Handled by onclose.
+        };
+    }
+
+    private closeSocket(): void {
+        if (this.socket !== null) {
+            this.socket.onopen = null;
+            this.socket.onmessage = null;
+            this.socket.onclose = null;
+            this.socket.onerror = null;
+            this.socket.close();
+            this.socket = null;
+        }
+    }
+
+    private cancelPendingReconnect(): void {
+        if (this.reconnectTimerId !== null) {
+            clearTimeout(this.reconnectTimerId);
+            this.reconnectTimerId = null;
+        }
+    }
+
+    private buildWebSocketUrl(flowId: number): string | null {
+        const token = this.authService.getAccessToken();
+        if (!token) {
+            return null;
+        }
+
+        const realtimeBase = this.configService.realtimeApiUrl;
+        const wsBase = realtimeBase.replace(/^https:\/\//i, 'wss://').replace(/^http:\/\//i, 'ws://');
+        const normalizedBase = wsBase.endsWith('/') ? wsBase : `${wsBase}/`;
+
+        return `${normalizedBase}collab/?flow_id=${flowId}&token=${encodeURIComponent(token)}`;
+    }
+}
+
+function isPresenceMessage(value: unknown): value is PresenceMessage {
+    return (
+        typeof value === 'object' &&
+        value !== null &&
+        (value as Record<string, unknown>)['type'] === 'presence' &&
+        typeof (value as Record<string, unknown>)['flow_id'] === 'number' &&
+        typeof (value as Record<string, unknown>)['count'] === 'number'
+    );
+}

--- a/src/realtime/api/main.py
+++ b/src/realtime/api/main.py
@@ -39,6 +39,8 @@ from utils.auth import introspect_token
 
 from infrastructure.persistence.database import get_db, engine
 from infrastructure.persistence.db_models import Base
+from infrastructure.persistence.presence_repository import PresenceRepository
+from application.presence_service import PresenceService
 from fastapi import Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -74,6 +76,9 @@ app.add_middleware(
 
 
 connection_repository = ConnectionRepository()
+
+presence_repository = PresenceRepository(redis_service=redis_service)
+presence_service = PresenceService(repository=presence_repository)
 
 _voice_settings_cache: dict | None = None
 _voice_settings_cache_time: float = 0.0
@@ -129,7 +134,9 @@ async def _run_forever(coro_fn, name: str, restart_delay: float = 2.0):
     while True:
         try:
             await coro_fn()
-            logger.warning(f"{name} exited unexpectedly, restarting in {restart_delay}s")
+            logger.warning(
+                f"{name} exited unexpectedly, restarting in {restart_delay}s"
+            )
         except Exception as e:
             logger.error(f"{name} crashed: {e}, restarting in {restart_delay}s")
         await asyncio.sleep(restart_delay)
@@ -244,6 +251,59 @@ async def root(
     await service.execute()
 
 
+@app.websocket("/realtime/collab/")
+async def collab_presence(
+    websocket: WebSocket,
+    flow_id: int | None = None,
+    token: str | None = None,
+):
+    """Collaborative presence counter for the flow editor.
+
+    Query params:
+        flow_id (int, required)  — identifies the flow being edited.
+        token   (str, required)  — JWT; validated via introspect_token.
+
+    On connect the client is added to the flow's presence set.  Every
+    mutation (join or leave) broadcasts::
+
+        {"type": "presence", "flow_id": <int>, "count": <int>}
+
+    to all connections on that flow.  The client sends nothing; the
+    receive loop exists solely to detect a disconnect.
+    """
+    if not token:
+        logger.warning("collab_presence: missing token, closing 1008")
+        await websocket.close(code=1008)
+        return
+
+    user_info = introspect_token(token)
+    if not user_info:
+        logger.warning("collab_presence: invalid token, closing 1008")
+        await websocket.close(code=1008)
+        return
+
+    if flow_id is None:
+        logger.warning("collab_presence: missing flow_id, closing 1008")
+        await websocket.close(code=1008)
+        return
+
+    await websocket.accept()
+    member_id: str | None = None
+    try:
+        member_id = await presence_service.join(flow_id, websocket)
+        logger.info("collab_presence: accepted flow={} member={}", flow_id, member_id)
+        while True:
+            # Block until the client disconnects (we don't process messages).
+            await websocket.receive_text()
+    except WebSocketDisconnect:
+        logger.info(
+            "collab_presence: disconnected flow={} member={}", flow_id, member_id
+        )
+    finally:
+        if member_id is not None:
+            await presence_service.leave(flow_id, websocket, member_id)
+
+
 @app.websocket("/ht")
 async def healthcheck_endpoint(websocket: WebSocket):
     await websocket.accept()
@@ -340,7 +400,9 @@ async def voice_stream(twilio_ws: WebSocket):
                 await twilio_ws.close()
                 return
             conn_key = resp.json().get("connection_key")
-            logger.info(f"Init realtime response: status={resp.status_code} conn_key={conn_key}")
+            logger.info(
+                f"Init realtime response: status={resp.status_code} conn_key={conn_key}"
+            )
         except Exception as e:
             logger.error(f"Failed to init realtime session: {e}")
             await twilio_ws.close()

--- a/src/realtime/application/presence_service.py
+++ b/src/realtime/application/presence_service.py
@@ -1,0 +1,90 @@
+import json
+import uuid
+from fastapi import WebSocket
+from loguru import logger
+
+from infrastructure.persistence.presence_repository import PresenceRepository
+
+
+class PresenceService:
+    """Manages per-flow WebSocket presence.
+
+    Maintains an in-process registry of live sockets for fan-out broadcast
+    (single-worker deployment — no cross-worker pub/sub needed).
+
+    Redis presence SET (``presence:flow:{flow_id}``) is the durable count
+    store so that the count survives across service restarts and reflects
+    exactly the connections registered in this process.
+    """
+
+    def __init__(self, repository: PresenceRepository) -> None:
+        self._repository = repository
+        # flow_id -> set of live WebSocket objects
+        self._sockets: dict[int, set[WebSocket]] = {}
+
+    async def join(self, flow_id: int, websocket: WebSocket) -> str:
+        """Register a new connection for flow_id.
+
+        Returns the opaque member_id (uuid4 hex) assigned to this connection.
+        Broadcasts the updated count to all connections on the flow.
+        """
+        member_id = uuid.uuid4().hex
+
+        # Redis write first: if it fails, the socket is never registered locally
+        # so there is no local/Redis count mismatch.
+        await self._repository.add_member(flow_id, member_id)
+
+        if flow_id not in self._sockets:
+            self._sockets[flow_id] = set()
+        self._sockets[flow_id].add(websocket)
+
+        await self._broadcast(flow_id)
+
+        logger.info("presence JOIN flow={} member={}", flow_id, member_id)
+        return member_id
+
+    async def leave(self, flow_id: int, websocket: WebSocket, member_id: str) -> None:
+        """Deregister a connection for flow_id.
+
+        Broadcasts the decremented count to all remaining connections.
+        Safe to call even if the socket was already removed.
+        """
+        flow_sockets = self._sockets.get(flow_id)
+        if flow_sockets is not None:
+            flow_sockets.discard(websocket)
+            if not flow_sockets:
+                del self._sockets[flow_id]
+
+        await self._repository.remove_member(flow_id, member_id)
+        await self._broadcast(flow_id)
+
+        logger.info("presence LEAVE flow={} member={}", flow_id, member_id)
+
+    async def _broadcast(self, flow_id: int) -> None:
+        """SCARD the flow's Redis set and fan-out to all live sockets.
+
+        Dead sockets are silently dropped from the registry.
+        """
+        count = await self._repository.count(flow_id)
+        message = json.dumps({"type": "presence", "flow_id": flow_id, "count": count})
+
+        flow_sockets = list(self._sockets.get(flow_id, set()))
+        dead: list[WebSocket] = []
+
+        for ws in flow_sockets:
+            try:
+                await ws.send_text(message)
+            except Exception:
+                # Socket is no longer alive; mark for removal, do not crash.
+                logger.warning(
+                    "presence broadcast: dead socket on flow={}, removing", flow_id
+                )
+                dead.append(ws)
+
+        if dead:
+            surviving = self._sockets.get(flow_id)
+            if surviving is not None:
+                for ws in dead:
+                    surviving.discard(ws)
+                if not surviving:
+                    del self._sockets[flow_id]

--- a/src/realtime/infrastructure/persistence/presence_repository.py
+++ b/src/realtime/infrastructure/persistence/presence_repository.py
@@ -1,0 +1,32 @@
+from loguru import logger
+
+from infrastructure.messaging.redis_service import RedisService
+
+
+class PresenceRepository:
+    """Thin Redis adapter for the presence SET per flow.
+
+    Key schema: ``presence:flow:{flow_id}``
+    Members:    per-connection UUID4 hex strings
+    """
+
+    def __init__(self, redis_service: RedisService) -> None:
+        self._redis = redis_service
+
+    def _key(self, flow_id: int) -> str:
+        return f"presence:flow:{flow_id}"
+
+    async def add_member(self, flow_id: int, member_id: str) -> None:
+        """SADD member_id to the flow's presence set."""
+        await self._redis.aioredis_client.sadd(self._key(flow_id), member_id)
+        logger.debug("presence SADD flow={} member={}", flow_id, member_id)
+
+    async def remove_member(self, flow_id: int, member_id: str) -> None:
+        """SREM member_id from the flow's presence set."""
+        await self._redis.aioredis_client.srem(self._key(flow_id), member_id)
+        logger.debug("presence SREM flow={} member={}", flow_id, member_id)
+
+    async def count(self, flow_id: int) -> int:
+        """Return SCARD (number of live connections) for a flow."""
+        result = await self._redis.aioredis_client.scard(self._key(flow_id))
+        return int(result)

--- a/src/realtime/tests/test_collab_presence.py
+++ b/src/realtime/tests/test_collab_presence.py
@@ -1,0 +1,317 @@
+"""Integration tests for the collab presence WebSocket endpoint.
+
+Covers all four acceptance criteria:
+  AC1 – invalid/missing token → close 1008
+  AC2 – two clients on the same flow both receive count 2
+  AC3 – one disconnect → remaining client receives count 1
+  AC4 – connections on different flow_ids are fully isolated
+
+The test module builds a minimal FastAPI app around the real
+``PresenceService`` + ``PresenceRepository`` backed by a FakeRedis client.
+It never imports ``api.main`` or ``utils.auth`` (which require env vars and
+optional third-party deps not installed in this environment).
+"""
+
+import asyncio
+import json
+from collections.abc import Callable
+from types import SimpleNamespace
+
+import fakeredis.aioredis as fake_aioredis
+import pytest
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+from fastapi.testclient import TestClient
+
+from application.presence_service import PresenceService
+from infrastructure.persistence.presence_repository import PresenceRepository
+
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_fake_repo() -> PresenceRepository:
+    """Build a PresenceRepository backed by an in-process FakeRedis client."""
+    fake_client = fake_aioredis.FakeRedis()
+    fake_redis_service = SimpleNamespace(aioredis_client=fake_client)
+    return PresenceRepository(redis_service=fake_redis_service)  # type: ignore[arg-type]
+
+
+def _build_app(
+    presence_service: PresenceService,
+    introspect_fn: Callable[[str], dict | None],
+) -> FastAPI:
+    """Return a minimal FastAPI app that only exposes the collab presence route.
+
+    ``introspect_fn`` is injected so tests never import ``utils.auth``
+    (which pulls in ``core.config.settings`` and requires all env vars).
+    """
+    app = FastAPI()
+
+    @app.websocket("/realtime/collab/")
+    async def collab_presence(
+        websocket: WebSocket,
+        flow_id: int | None = None,
+        token: str | None = None,
+    ):
+        if not token:
+            await websocket.close(code=1008)
+            return
+
+        user_info = introspect_fn(token)
+        if not user_info:
+            await websocket.close(code=1008)
+            return
+
+        if flow_id is None:
+            await websocket.close(code=1008)
+            return
+
+        await websocket.accept()
+        member_id: str | None = None
+        try:
+            member_id = await presence_service.join(flow_id, websocket)
+            while True:
+                await websocket.receive_text()
+        except WebSocketDisconnect:
+            pass
+        finally:
+            if member_id is not None:
+                await presence_service.leave(flow_id, websocket, member_id)
+
+    return app
+
+
+# A valid user payload returned by a successful token introspection.
+_VALID_USER = {"active": True, "user_id": 1, "username": "test"}
+
+
+def _valid_introspect(token: str) -> dict | None:
+    return _VALID_USER
+
+
+def _invalid_introspect(token: str) -> dict | None:
+    return None
+
+
+# ---------------------------------------------------------------------------
+# AC1 – authentication failures close with code 1008
+# ---------------------------------------------------------------------------
+
+
+class TestAuthRejection:
+    """Missing or invalid tokens must cause an abnormal close (1008)."""
+
+    def test_missing_token_closes_1008(self):
+        service = PresenceService(repository=_make_fake_repo())
+        app = _build_app(service, _valid_introspect)
+
+        with TestClient(app) as client:
+            with pytest.raises(Exception):
+                # Starlette TestClient raises WebSocketDenied / similar on 1008.
+                with client.websocket_connect("/realtime/collab/?flow_id=1") as ws:
+                    ws.receive_text()
+
+    def test_invalid_token_closes_1008(self):
+        service = PresenceService(repository=_make_fake_repo())
+        app = _build_app(service, _invalid_introspect)
+
+        with TestClient(app) as client:
+            with pytest.raises(Exception):
+                with client.websocket_connect(
+                    "/realtime/collab/?flow_id=1&token=bad"
+                ) as ws:
+                    ws.receive_text()
+
+    def test_missing_flow_id_closes_1008(self):
+        service = PresenceService(repository=_make_fake_repo())
+        app = _build_app(service, _valid_introspect)
+
+        with TestClient(app) as client:
+            with pytest.raises(Exception):
+                with client.websocket_connect("/realtime/collab/?token=valid") as ws:
+                    ws.receive_text()
+
+
+# ---------------------------------------------------------------------------
+# AC2 – two clients on the same flow both receive count 2
+# ---------------------------------------------------------------------------
+
+
+class TestTwoClientsOnSameFlow:
+    """Second connection broadcasts count 2 to all sockets on the flow."""
+
+    def test_second_join_broadcasts_count_two_to_both(self):
+        repo = _make_fake_repo()
+        service = PresenceService(repository=repo)
+        app = _build_app(service, _valid_introspect)
+
+        with TestClient(app) as client:
+            with client.websocket_connect(
+                "/realtime/collab/?flow_id=10&token=t"
+            ) as ws1:
+                # First join → count 1 (only ws1 in the flow).
+                msg1 = json.loads(ws1.receive_text())
+                assert msg1 == {"type": "presence", "flow_id": 10, "count": 1}
+
+                with client.websocket_connect(
+                    "/realtime/collab/?flow_id=10&token=t"
+                ) as ws2:
+                    # ws2 just joined — it receives its own join broadcast.
+                    msg_ws2 = json.loads(ws2.receive_text())
+                    assert msg_ws2 == {
+                        "type": "presence",
+                        "flow_id": 10,
+                        "count": 2,
+                    }
+                    # ws1 also received the broadcast when ws2 joined.
+                    msg_ws1_update = json.loads(ws1.receive_text())
+                    assert msg_ws1_update == {
+                        "type": "presence",
+                        "flow_id": 10,
+                        "count": 2,
+                    }
+
+
+# ---------------------------------------------------------------------------
+# AC3 – disconnect → remaining connections receive decremented count
+# ---------------------------------------------------------------------------
+
+
+class TestDisconnectDecrementsCount:
+    """When a socket disconnects, the remaining sockets receive count - 1."""
+
+    def test_leave_broadcasts_count_one_to_remaining(self):
+        repo = _make_fake_repo()
+        service = PresenceService(repository=repo)
+        app = _build_app(service, _valid_introspect)
+
+        with TestClient(app) as client:
+            with client.websocket_connect(
+                "/realtime/collab/?flow_id=20&token=t"
+            ) as ws1:
+                # Consume join broadcast (count 1).
+                ws1.receive_text()
+
+                with client.websocket_connect(
+                    "/realtime/collab/?flow_id=20&token=t"
+                ) as ws2:
+                    # Consume ws2's own join broadcast.
+                    ws2.receive_text()
+                    # Consume the same broadcast on ws1.
+                    ws1.receive_text()
+
+                # ws2 context exited → disconnect → `leave` fires → count drops to 1.
+                # ws1 must receive the decremented count.
+                leave_msg = json.loads(ws1.receive_text())
+                assert leave_msg == {
+                    "type": "presence",
+                    "flow_id": 20,
+                    "count": 1,
+                }
+
+
+# ---------------------------------------------------------------------------
+# AC4 – different flow_ids are fully isolated
+# ---------------------------------------------------------------------------
+
+
+class TestFlowIsolation:
+    """Connections on different flows must not affect each other's counts."""
+
+    def test_different_flows_see_independent_counts(self):
+        repo = _make_fake_repo()
+        service = PresenceService(repository=repo)
+        app = _build_app(service, _valid_introspect)
+
+        with TestClient(app) as client:
+            with client.websocket_connect(
+                "/realtime/collab/?flow_id=100&token=t"
+            ) as ws_flow_100:
+                # flow 100 starts at 1.
+                msg_100 = json.loads(ws_flow_100.receive_text())
+                assert msg_100 == {
+                    "type": "presence",
+                    "flow_id": 100,
+                    "count": 1,
+                }
+
+                with client.websocket_connect(
+                    "/realtime/collab/?flow_id=200&token=t"
+                ) as ws_flow_200:
+                    # flow 200 starts independently at 1.
+                    msg_200 = json.loads(ws_flow_200.receive_text())
+                    assert msg_200 == {
+                        "type": "presence",
+                        "flow_id": 200,
+                        "count": 1,
+                    }
+
+                # ws_flow_200 disconnected: flow 200 count drops to 0.
+                # Verify Redis counts reflect isolation.
+                count_100 = asyncio.run(repo.count(100))
+                count_200 = asyncio.run(repo.count(200))
+
+                assert count_100 == 1, f"flow 100 count should be 1, got {count_100}"
+                assert count_200 == 0, f"flow 200 count should be 0, got {count_200}"
+
+            # ws_flow_100 also disconnected now.
+            final_100 = asyncio.run(repo.count(100))
+            assert (
+                final_100 == 0
+            ), f"flow 100 should be 0 after ws disconnect, got {final_100}"
+
+
+# ---------------------------------------------------------------------------
+# AC5 – Redis failure during join leaves no local socket registered
+# ---------------------------------------------------------------------------
+
+
+class TestJoinRedisFailure:
+    """If Redis raises during join, no socket must be registered locally and
+    a second client on the same flow must see a correct count of 1."""
+
+    def test_redis_failure_leaves_no_local_socket_and_route_closes_cleanly(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        repo = _make_fake_repo()
+        service = PresenceService(repository=repo)
+        app = _build_app(service, _valid_introspect)
+
+        # Patch add_member to raise only on the first call, simulating a Redis
+        # failure during the first client's join.
+        original_add_member = repo.add_member
+        call_count = 0
+
+        async def _failing_add_member(flow_id: int, member_id: str) -> None:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise RuntimeError("simulated Redis failure")
+            await original_add_member(flow_id, member_id)
+
+        monkeypatch.setattr(repo, "add_member", _failing_add_member)
+
+        with TestClient(app) as client:
+            # First connection: join fails at Redis — route must close without
+            # NameError and the socket must NOT be in _sockets.
+            with pytest.raises(Exception):
+                with client.websocket_connect(
+                    "/realtime/collab/?flow_id=42&token=t"
+                ) as ws_bad:
+                    ws_bad.receive_text()
+
+            # No local socket must remain after the failed join.
+            assert (
+                service._sockets.get(42) is None
+                or len(service._sockets.get(42, set())) == 0
+            )
+
+            # Second connection succeeds normally.
+            with client.websocket_connect(
+                "/realtime/collab/?flow_id=42&token=t"
+            ) as ws_ok:
+                msg = json.loads(ws_ok.receive_text())
+                # Redis has exactly 1 member; local count matches.
+                assert msg == {"type": "presence", "flow_id": 42, "count": 1}


### PR DESCRIPTION
…ant counter)

Authenticated /realtime/collab/ WebSocket route with Redis-backed per-flow presence (presence:flow:{id} sets, per-connection UUID members), in-process fan-out broadcast {type, flow_id, count}, frontend CollaborationPresenceService (signals, single-retry reconnect) wired into the flow editor host with a count indicator. Walking skeleton for the Flow Editor Live Collaboration epic (EST-1): proves FE <-> realtime WS auth <-> Redis <-> broadcast <-> FE render.