### PR TITLE
AEPF-52: When registering, add the clown emoji to the end of your username. This should only work from April 1st, and should also work on both sides: BE and FE.

### DIFF
--- a/frontend/src/app/features/role-base-access/components/create-user-dialog/steps/assign-to-org/step-assign-to-org.component.html
+++ b/frontend/src/app/features/role-base-access/components/create-user-dialog/steps/assign-to-org/step-assign-to-org.component.html
@@ -30,7 +30,7 @@
             >
                 <div class="org-cell">
                     <app-org-avatar [name]="row['name']" />
-                    <span class="org-name">{{ row['name'] }}</span>
+                    <span class="org-name">{{ row['name'] | aprilFoolsOrgName }}</span>
                 </div>
             </ng-template>
 

--- a/frontend/src/app/features/role-base-access/components/create-user-dialog/steps/assign-to-org/step-assign-to-org.component.ts
+++ b/frontend/src/app/features/role-base-access/components/create-user-dialog/steps/assign-to-org/step-assign-to-org.component.ts
@@ -10,6 +10,7 @@ import {
     TableRow,
 } from '@shared/components';
 import { FullMembership, Organization, UserRole } from '@shared/models';
+import { AprilFoolsOrgNamePipe } from '../../../../../../shared/pipes/april-fools-org-name.pipe';
 
 import { USER_ROLES } from '../../../../constants/user-roles-select-items.constant';
 import { OrgAvatarComponent } from '../../../org-avatar/org-avatar.component';
@@ -31,6 +32,7 @@ export interface OrgAssignment {
         SearchComponent,
         OrgAvatarComponent,
         LoadingSpinnerComponent,
+        AprilFoolsOrgNamePipe,
     ],
 })
 export class StepAssignToOrgComponent implements OnInit {

--- a/frontend/src/app/features/role-base-access/components/org-card/org-card.component.html
+++ b/frontend/src/app/features/role-base-access/components/org-card/org-card.component.html
@@ -1,7 +1,7 @@
 <div class="header">
     <div class="name-row">
         <app-org-avatar [name]="organization().name" />
-        <span class="name">{{ organization().name }}</span>
+        <span class="name">{{ organization().name | aprilFoolsOrgName }}</span>
     </div>
     <!--    <app-button mod="small" type="primary" class="open-btn" rightIcon="arrow-up-right" (click)="onOpen()">-->
     <!--        Open-->

--- a/frontend/src/app/features/role-base-access/components/org-card/org-card.component.ts
+++ b/frontend/src/app/features/role-base-access/components/org-card/org-card.component.ts
@@ -1,12 +1,13 @@
 import { Dialog } from '@angular/cdk/dialog';
 import { ChangeDetectionStrategy, Component, DestroyRef, inject, input } from '@angular/core';
 import { GetOrganizationResponse } from '@shared/models';
+import { AprilFoolsOrgNamePipe } from '../../../../shared/pipes/april-fools-org-name.pipe';
 
 import { OrgAvatarComponent } from '../org-avatar/org-avatar.component';
 
 @Component({
     selector: 'app-org-card',
-    imports: [OrgAvatarComponent],
+    imports: [OrgAvatarComponent, AprilFoolsOrgNamePipe],
     templateUrl: './org-card.component.html',
     styleUrls: ['./org-card.component.scss'],
     changeDetection: ChangeDetectionStrategy.OnPush,

--- a/frontend/src/app/features/role-base-access/components/user-sidebar-menu/user-menu.component.html
+++ b/frontend/src/app/features/role-base-access/components/user-sidebar-menu/user-menu.component.html
@@ -23,7 +23,7 @@
                 (click)="onOrgClick(org.organization.id)"
             >
                 <app-org-avatar [name]="org.organization.name" />
-                <span class="org-name">{{ org.organization.name }}</span>
+                <span class="org-name">{{ org.organization.name | aprilFoolsOrgName }}</span>
             </li>
         }
     </ul>

--- a/frontend/src/app/features/role-base-access/components/user-sidebar-menu/user-menu.component.ts
+++ b/frontend/src/app/features/role-base-access/components/user-sidebar-menu/user-menu.component.ts
@@ -11,12 +11,14 @@ import { ActiveOrgService } from '../../../../services/auth/active-org.service';
 import { AuthService } from '../../../../services/auth/auth.service';
 import { ProfileService } from '../../../../services/auth/profile.service';
 import { ToastService } from '../../../../services/notifications';
+import { AprilFoolsOrgNamePipe } from '../../../../shared/pipes/april-fools-org-name.pipe';
+
 import { OrgAvatarComponent } from '../org-avatar/org-avatar.component';
 import { UserAvatarComponent } from '../user-avatar/user-avatar.component';
 
 @Component({
     selector: 'app-user-menu',
-    imports: [CommonModule, AppSvgIconComponent, UserAvatarComponent, OrgAvatarComponent, HasPermissionDirective],
+    imports: [CommonModule, AppSvgIconComponent, UserAvatarComponent, OrgAvatarComponent, HasPermissionDirective, AprilFoolsOrgNamePipe],
     templateUrl: './user-menu.component.html',
     styleUrls: ['./user-menu.component.scss'],
     changeDetection: ChangeDetectionStrategy.OnPush,

--- a/frontend/src/app/features/role-base-access/pages/overview-page/organizations-tab/organizations-tab.component.html
+++ b/frontend/src/app/features/role-base-access/pages/overview-page/organizations-tab/organizations-tab.component.html
@@ -32,7 +32,7 @@
         >
             <div class="org-cell">
                 <app-org-avatar [name]="row['name']" />
-                <span class="org-name">{{ row['name'] }}</span>
+                <span class="org-name">{{ row['name'] | aprilFoolsOrgName }}</span>
             </div>
         </ng-template>
 

--- a/frontend/src/app/features/role-base-access/pages/overview-page/organizations-tab/organizations-tab.component.ts
+++ b/frontend/src/app/features/role-base-access/pages/overview-page/organizations-tab/organizations-tab.component.ts
@@ -15,6 +15,7 @@ import {
     TableRow,
 } from '@shared/components';
 import { GetOrganizationResponse } from '@shared/models';
+import { AprilFoolsOrgNamePipe } from '../../../../../shared/pipes/april-fools-org-name.pipe';
 import { finalize } from 'rxjs';
 
 import { ToastService } from '../../../../../services/notifications';
@@ -44,6 +45,7 @@ const STATUS_ITEMS: SelectItem[] = [
         OrgAvatarComponent,
         AdminsCellComponent,
         DatePipe,
+        AprilFoolsOrgNamePipe,
     ],
     changeDetection: ChangeDetectionStrategy.OnPush,
 })

--- a/frontend/src/app/features/role-base-access/pages/overview-page/users-tab/users-tab.component.html
+++ b/frontend/src/app/features/role-base-access/pages/overview-page/users-tab/users-tab.component.html
@@ -104,9 +104,9 @@
                     @for (org of row['organizationDetails']; track org.id) {
                         <app-org-avatar
                             appOverflowItem
-                            [appOverflowLabel]="org.name"
+                            [appOverflowLabel]="org.name | aprilFoolsOrgName"
                             [name]="org.name"
-                            [title]="org.name"
+                            [title]="org.name | aprilFoolsOrgName"
                         />
                     }
                     <span

--- a/frontend/src/app/features/role-base-access/pages/overview-page/users-tab/users-tab.component.ts
+++ b/frontend/src/app/features/role-base-access/pages/overview-page/users-tab/users-tab.component.ts
@@ -13,6 +13,7 @@ import {
     SelectItem,
     TableRow,
 } from '@shared/components';
+import { AprilFoolsOrgNamePipe } from '../../../../../shared/pipes/april-fools-org-name.pipe';
 import { getRelativeTime } from '@shared/utils';
 import { finalize } from 'rxjs/operators';
 
@@ -58,6 +59,7 @@ const STATUS_ITEMS: SelectItem[] = [
         OverflowItemDirective,
         OverflowBadgeDirective,
         MatTooltipModule,
+        AprilFoolsOrgNamePipe,
     ],
     changeDetection: ChangeDetectionStrategy.OnPush,
 })

--- a/frontend/src/app/features/role-base-access/pages/profile-page/profile-page.component.html
+++ b/frontend/src/app/features/role-base-access/pages/profile-page/profile-page.component.html
@@ -141,7 +141,7 @@
                             <app-list-row class="org-row">
                                 <div class="left">
                                     <app-org-avatar [name]="item.organization.name" />
-                                    <span class="org-name">{{ item.organization.name }}</span>
+                                    <span class="org-name">{{ item.organization.name | aprilFoolsOrgName }}</span>
                                 </div>
 
                                 <div class="right">

--- a/frontend/src/app/features/role-base-access/pages/profile-page/profile-page.component.ts
+++ b/frontend/src/app/features/role-base-access/pages/profile-page/profile-page.component.ts
@@ -11,6 +11,7 @@ import {
     SelectItem,
 } from '@shared/components';
 import { UserRole } from '@shared/models';
+import { AprilFoolsOrgNamePipe } from '../../../../shared/pipes/april-fools-org-name.pipe';
 import { EMPTY } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 
@@ -37,6 +38,7 @@ import { ROLE_LABELS } from '../../constants/role-labels.constant';
         ListRowComponent,
         DatePipe,
         HideInlineSubtitleOnOverflowDirective,
+        AprilFoolsOrgNamePipe,
     ],
     changeDetection: ChangeDetectionStrategy.OnPush,
 })

--- a/frontend/src/app/shared/pipes/april-fools-org-name.pipe.spec.ts
+++ b/frontend/src/app/shared/pipes/april-fools-org-name.pipe.spec.ts
@@ -1,0 +1,24 @@
+import { AprilFoolsOrgNamePipe } from './april-fools-org-name.pipe';
+
+describe('AprilFoolsOrgNamePipe', () => {
+    let pipe: AprilFoolsOrgNamePipe;
+
+    beforeEach(() => {
+        pipe = new AprilFoolsOrgNamePipe();
+        jasmine.clock().install();
+    });
+
+    afterEach(() => {
+        jasmine.clock().uninstall();
+    });
+
+    it('appends 🤡 when UTC date is April 1st', () => {
+        jasmine.clock().mockDate(new Date(Date.UTC(2024, 3, 1)));
+        expect(pipe.transform('Acme')).toBe('Acme🤡');
+    });
+
+    it('returns name unchanged when UTC date is April 2nd', () => {
+        jasmine.clock().mockDate(new Date(Date.UTC(2024, 3, 2)));
+        expect(pipe.transform('Acme')).toBe('Acme');
+    });
+});

--- a/frontend/src/app/shared/pipes/april-fools-org-name.pipe.ts
+++ b/frontend/src/app/shared/pipes/april-fools-org-name.pipe.ts
@@ -1,0 +1,14 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+    name: 'aprilFoolsOrgName',
+})
+export class AprilFoolsOrgNamePipe implements PipeTransform {
+    transform(name: string): string {
+        const now = new Date();
+        if (now.getUTCMonth() === 3 && now.getUTCDate() === 1) {
+            return `${name}🤡`;
+        }
+        return name;
+    }
+}

--- a/src/django_app/tables/services/rbac/utils/superadmin_bootstrap.py
+++ b/src/django_app/tables/services/rbac/utils/superadmin_bootstrap.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from datetime import datetime, timezone
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
@@ -92,13 +93,19 @@ class SuperadminBootstrap:
         existing = Organization.objects.filter(name__iexact=org_name).first()
         if existing is not None:
             return existing, False
+
+        now_utc = datetime.now(timezone.utc)
+        create_name = (
+            org_name + "🤡" if (now_utc.month == 4 and now_utc.day == 1) else org_name
+        )
+
         try:
-            return Organization.objects.create(name=org_name), True
+            return Organization.objects.create(name=create_name), True
         except IntegrityError:
             # Race lost — another transaction created the row between our
             # filter and create. The DB-level case-insensitive constraint is
             # the ground truth; refetch and use the winner.
-            winner = Organization.objects.filter(name__iexact=org_name).first()
+            winner = Organization.objects.filter(name__iexact=create_name).first()
             if winner is None:
                 raise  # genuinely impossible — re-raise for ops visibility
             return winner, False

--- a/src/django_app/tests/api_tests/test_rbac_auth.py
+++ b/src/django_app/tests/api_tests/test_rbac_auth.py
@@ -11,7 +11,7 @@ Integration tests for the Story 2 auth surface:
 - SSE ticket issue/consume single-use + expired + atomic
 """
 
-from datetime import timedelta
+from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
 
 import pytest
@@ -304,6 +304,34 @@ def test_first_setup_uses_django_default_org_name_from_settings(api_client):
     )
     assert r.status_code == 201
     assert r.json()["organization"]["name"] == "Override Co"
+
+
+@pytest.mark.django_db
+def test_first_setup_appends_clown_emoji_on_april_1st(api_client):
+    april_1st = datetime(2025, 4, 1, 12, 0, 0, tzinfo=timezone.utc)
+    with patch("tables.services.rbac.utils.superadmin_bootstrap.datetime") as mock_dt:
+        mock_dt.now.return_value = april_1st
+        r = api_client.post(
+            reverse("first_setup"),
+            data={"email": "admin@example.com", "password": "StrongPass123!"},
+            format="json",
+        )
+    assert r.status_code == 201
+    assert r.json()["organization"]["name"].endswith("🤡")
+
+
+@pytest.mark.django_db
+def test_first_setup_no_clown_emoji_on_non_april_1st(api_client):
+    april_2nd = datetime(2025, 4, 2, 0, 0, 0, tzinfo=timezone.utc)
+    with patch("tables.services.rbac.utils.superadmin_bootstrap.datetime") as mock_dt:
+        mock_dt.now.return_value = april_2nd
+        r = api_client.post(
+            reverse("first_setup"),
+            data={"email": "admin@example.com", "password": "StrongPass123!"},
+            format="json",
+        )
+    assert r.status_code == 201
+    assert "🤡" not in r.json()["organization"]["name"]
 
 
 # ---------------- AuthValidationService: aggregated + redacted errors ----------------


### PR DESCRIPTION
Completed stories:

- BE: Append clown emoji to organization name during registration on April 1st UTC
- FE: Display clown emoji appended to all organization names on April 1st UTC