### PR TITLE
fix(EST-3118-FE): Fix wrong epicchat request on prod env

### DIFF
--- a/frontend/src/app/layouts/main-layout/sidenav/sidenav.component.ts
+++ b/frontend/src/app/layouts/main-layout/sidenav/sidenav.component.ts
@@ -12,7 +12,6 @@ import {
 } from '@angular/core';
 import { RouterLink, RouterLinkActive } from '@angular/router';
 import { ClickOutsideDirective } from '@shared/directives';
-import { environment } from 'src/environments/environment';
 
 import { ConfigureModelsDialogService } from '../../../features/configure-models/services/configure-models-dialog.service';
 import { EpicChatService } from '../../../features/epic-chat/epic-chat.service';
@@ -143,7 +142,7 @@ export class LeftSidebarComponent implements AfterViewInit {
 
         // Bad approach to use window.location because ui and backend can be on different domains
         // fixed localhost vs 127.0.0.1 problem in widget code
-        this.apiBaseUrl = environment.apiUrl;
+        this.apiBaseUrl = this.configService.apiUrl;
         this.accessToken = this.authService.getAccessToken() ?? '';
         this.topNavItems = [
             {


### PR DESCRIPTION
## Description

<!-- Fix wrong epicchat request on prod env because of using environment.ts in epicchat - now using configService.apiUrl -->

## Checklist

- [ ] I have signed the **Contributor License Agreement (CLA)**. The CLA bot will comment on this PR — comment `I have read the CLA Document and I hereby sign the CLA` to sign. **This PR cannot be merged until the CLA is signed.**
- [ ] My code follows the project's style and conventions.
- [ ] I have tested my changes.
- [ ] I have updated documentation where needed.
