### PR TITLE
fix(EST-3117-FE): remove connection start markers and fix DT port

### DIFF
--- a/frontend/src/app/visual-programming/components/nodes-components/decision-table-node/decision-table-node.component.scss
+++ b/frontend/src/app/visual-programming/components/nodes-components/decision-table-node/decision-table-node.component.scss
@@ -16,8 +16,8 @@
     .input-port-wrapper {
         position: absolute;
         left: -12px;
-        top: 50%;
-        transform: translateY(-50%);
+        top: 16px;
+        transform: none;
         width: 24px;
         height: 24px;
         z-index: 2;

--- a/frontend/src/app/visual-programming/flow-graph/flow-graph.component.html
+++ b/frontend/src/app/visual-programming/flow-graph/flow-graph.component.html
@@ -166,28 +166,6 @@
                     ></f-connection-gradient>
 
                     <svg
-                        viewBox="0 0 10 10"
-                        fMarker
-                        [type]="eMarkerType.START"
-                        [height]="10"
-                        [width]="10"
-                        [refX]="5"
-                        [refY]="5"
-                    >
-                        <circle
-                            cx="5"
-                            cy="5"
-                            r="2"
-                            stroke="none"
-                            [attr.fill]="
-                                flowSettings.arrowColorsEnabled()
-                                    ? nodeColorMap().get(connection.sourceNodeId) || '#555'
-                                    : connection.startColor || '#555'
-                            "
-                        ></circle>
-                    </svg>
-
-                    <svg
                         viewBox="0 0 6 6"
                         fMarker
                         [type]="eMarkerType.END"
@@ -205,23 +183,6 @@
                                     : connection.endColor || '#555'
                             "
                         ></path>
-                    </svg>
-
-                    <svg
-                        viewBox="0 0 10 10"
-                        fMarker
-                        [type]="eMarkerType.SELECTED_START"
-                        [height]="10"
-                        [width]="10"
-                        [refX]="5"
-                        [refY]="5"
-                    >
-                        <circle
-                            cx="5"
-                            cy="5"
-                            r="2"
-                            stroke="none"
-                        ></circle>
                     </svg>
 
                     <svg


### PR DESCRIPTION
## Description

Fixes two visual issues in the flow editor:
  1. **Connection markers** — removed circle markers at the source end of connections; lines now originate directly from the port point.
  2. **Decision Table input port** — fixed input port position from center of full node height to center of header. This aligns it with standard nodes' output ports, making connections render  as straight lines.
<img width="622" height="261" alt="Screenshot 2026-06-18 001707" src="https://github.com/user-attachments/assets/5545eb29-a1b8-48f6-bd50-3c6f7fe8dded" />

## Checklist

- [ ] I have signed the **Contributor License Agreement (CLA)**. The CLA bot will comment on this PR — comment `I have read the CLA Document and I hereby sign the CLA` to sign. **This PR cannot be merged until the CLA is signed.**
- [ ] My code follows the project's style and conventions.
- [ ] I have tested my changes.
- [ ] I have updated documentation where needed.
