### PR TITLE
fix(EST-3123-FE): save flow after undo/redo of a node

### DIFF
--- a/frontend/src/app/pages/flows-page/components/flow-visual-programming/flow-visual-programming.component.ts
+++ b/frontend/src/app/pages/flows-page/components/flow-visual-programming/flow-visual-programming.component.ts
@@ -82,6 +82,7 @@ import { rewriteLegacyOnceScheduleName } from '../../../../visual-programming/ut
 import {
     buildBulkSavePayload,
     buildUuidToBackendIdMap,
+    clearStaleIds,
     cloneFlowState,
     getConnectionDiff,
     getNodeDiff,
@@ -271,14 +272,15 @@ export class FlowVisualProgrammingComponent implements OnInit, OnDestroy, CanCom
         if (!this.graph?.id) return EMPTY;
 
         const previous = this.loadedFlowState();
-        const nodeDiff = getNodeDiff(previous, flowState);
-        const idMap = buildUuidToBackendIdMap(flowState.nodes);
-        const connectionDiff = getConnectionDiff(previous, flowState, idMap);
+        const flowToSave = clearStaleIds(previous, flowState);
+        const nodeDiff = getNodeDiff(previous, flowToSave);
+        const idMap = buildUuidToBackendIdMap(flowToSave.nodes);
+        const connectionDiff = getConnectionDiff(previous, flowToSave, idMap);
         const payload = buildBulkSavePayload(
             this.graph.id,
             nodeDiff,
             connectionDiff,
-            flowState,
+            flowToSave,
             idMap,
             this.graphState()!.save_version
         );
@@ -295,7 +297,7 @@ export class FlowVisualProgrammingComponent implements OnInit, OnDestroy, CanCom
             tap(({ graph, flows }) => {
                 this.graphState.set(graph);
                 this.availableFlowLights.set(flows);
-                const patchedFlow = patchFlowStateWithBackendIds(flowState, previous, nodeDiff, graph);
+                const patchedFlow = patchFlowStateWithBackendIds(flowToSave, previous, nodeDiff, graph);
 
                 this.flowService.setFlow(patchedFlow);
                 // Sync isActive from the save response: patchFlowStateWithBackendIds only assigns

--- a/frontend/src/app/visual-programming/utils/save/clear-stale-ids.spec.ts
+++ b/frontend/src/app/visual-programming/utils/save/clear-stale-ids.spec.ts
@@ -1,0 +1,64 @@
+import { ConnectionModel } from '../../core/models/connection.model';
+import { FlowModel } from '../../core/models/flow.model';
+import { NodeModel } from '../../core/models/node.model';
+import { clearStaleIds } from './clear-stale-ids';
+
+function node(id: string, backendId: number | null): NodeModel {
+    return { id, backendId } as unknown as NodeModel;
+}
+
+function connection(id: string, edgeBackendId: number | null): ConnectionModel {
+    return {
+        id,
+        sourceNodeId: 'a',
+        targetNodeId: 'b',
+        data: edgeBackendId == null ? null : { id: edgeBackendId },
+    } as unknown as ConnectionModel;
+}
+
+describe('clearStaleIds', () => {
+    it('clears backendId on a node whose backendId is not in the baseline (resurrected by undo)', () => {
+        const previous: FlowModel = { nodes: [node('keep-uuid', 5)], connections: [] };
+        const current: FlowModel = {
+            nodes: [node('keep-uuid', 5), node('resurrected-uuid', 3)],
+            connections: [],
+        };
+
+        const result = clearStaleIds(previous, current);
+
+        const persisted = result.nodes.find((n) => n.id === 'keep-uuid');
+        const orphaned = result.nodes.find((n) => n.id === 'resurrected-uuid');
+        expect(persisted!.backendId).toBe(5); // untouched
+        expect(orphaned!.backendId).toBeNull(); // cleared -> treated as new (temp_id)
+    });
+
+    it('clears data on a connection whose edge id is not in the baseline', () => {
+        const previous: FlowModel = { nodes: [], connections: [connection('c-keep', 10)] };
+        const current: FlowModel = {
+            nodes: [],
+            connections: [connection('c-keep', 10), connection('c-orphan', 7)],
+        };
+
+        const result = clearStaleIds(previous, current);
+
+        expect(result.connections.find((c) => c.id === 'c-keep')!.data?.id).toBe(10);
+        expect(result.connections.find((c) => c.id === 'c-orphan')!.data).toBeNull();
+    });
+
+    it('is a no-op when there are no stale ids', () => {
+        const previous: FlowModel = {
+            nodes: [node('x', 1)],
+            connections: [connection('c', 2)],
+        };
+        const current: FlowModel = {
+            nodes: [node('x', 1), node('new', null)],
+            connections: [connection('c', 2)],
+        };
+
+        const result = clearStaleIds(previous, current);
+
+        expect(result.nodes.find((n) => n.id === 'x')!.backendId).toBe(1);
+        expect(result.nodes.find((n) => n.id === 'new')!.backendId).toBeNull();
+        expect(result.connections[0].data?.id).toBe(2);
+    });
+});

--- a/frontend/src/app/visual-programming/utils/save/clear-stale-ids.ts
+++ b/frontend/src/app/visual-programming/utils/save/clear-stale-ids.ts
@@ -1,0 +1,26 @@
+import { FlowModel } from '../../core/models/flow.model';
+
+/**
+ * Drops backendId / edge id from nodes and connections that point at DB rows
+ * which no longer exist in the last-saved baseline. This happens when a node or
+ * edge is deleted, the deletion is saved, and then UNDO brings it back with its
+ * now-stale id. Clearing the id (so it becomes null) makes the save treat the
+ * item as brand-new, so the backend recreates it instead of rejecting an edge
+ * that references a node that is already gone.
+ */
+export function clearStaleIds(previous: FlowModel, current: FlowModel): FlowModel {
+    const savedNodeIds = new Set<number>();
+    for (const n of previous.nodes) if (n.backendId != null) savedNodeIds.add(n.backendId);
+
+    const savedEdgeIds = new Set<number>();
+    for (const c of previous.connections) if (c.data?.id != null) savedEdgeIds.add(c.data.id);
+
+    const nodes = current.nodes.map((n) =>
+        n.backendId != null && !savedNodeIds.has(n.backendId) ? { ...n, backendId: null } : n
+    );
+    const connections = current.connections.map((c) =>
+        c.data?.id != null && !savedEdgeIds.has(c.data.id) ? { ...c, data: null } : c
+    );
+
+    return { ...current, nodes, connections };
+}

--- a/frontend/src/app/visual-programming/utils/save/index.ts
+++ b/frontend/src/app/visual-programming/utils/save/index.ts
@@ -1,3 +1,4 @@
+export { clearStaleIds } from './clear-stale-ids';
 export { buildUuidToBackendIdMap, getConnectionDiff, getNodeDiff } from './diff';
 export { patchFlowStateWithBackendIds } from './patch';
 export { buildBulkSavePayload } from './payload';


### PR DESCRIPTION

## Description

Undo restores a deleted+saved node with its stale backendId, so the save payload referenced a node id no longer in the DB and was rejected with "Edge references node IDs that do not exist". Clear backendIds/edge-ids that are absent from the last-saved baseline before building the payload, so resurrected nodes/edges are recreated via temp_id instead.


## Checklist

- [x] I have signed the **Contributor License Agreement (CLA)**. The CLA bot will comment on this PR — comment `I have read the CLA Document and I hereby sign the CLA` to sign. **This PR cannot be merged until the CLA is signed.**
- [x] My code follows the project's style and conventions.
- [x] I have tested my changes.
- [x] I have updated documentation where needed.
