### PR TITLE
fix: add backwards compatibility for new args_schema in tools

### DIFF
--- a/frontend/src/app/user-settings-page/tools/custom-tool-editor/create-custom-tool-dialog/components/parameters-table.config.ts
+++ b/frontend/src/app/user-settings-page/tools/custom-tool-editor/create-custom-tool-dialog/components/parameters-table.config.ts
@@ -481,7 +481,7 @@ export function serializeVariables(vars: ToolVariable[]): BackendToolVariable[] 
             out.required_properties = nested.required_properties;
         }
         if (v.type === 'array') {
-            out.item = { ...ARRAY_ITEM_SCHEMA };
+            out.item = v.items ? (v.items as unknown as PropertySchema) : { ...ARRAY_ITEM_SCHEMA };
             out.default_value = buildValue(v);
         }
 
@@ -567,6 +567,9 @@ export function deserializeVariables(data: unknown): ToolVariable[] {
         if (type === 'array') {
             variable.children = arrayDefaultToVariables(item.default_value, item.input_type);
             variable.default_value = null;
+            if (isObjectRecord(item.item)) {
+                variable.items = item.item as unknown as ItemsSchema;
+            }
         }
 
         result.push(variable);

--- a/src/django_app/tables/import_export/constants.py
+++ b/src/django_app/tables/import_export/constants.py
@@ -1,6 +1,6 @@
 from tables.import_export.enums import EntityType
 
-IMPORT_VERSION = 1
+IMPORT_VERSION = 2
 
 MAIN_ENTITY_KEY = "main_entity"
 NODE_MAPPING_KEY = "node"

--- a/src/django_app/tables/import_export/version_conversions/convertions.py
+++ b/src/django_app/tables/import_export/version_conversions/convertions.py
@@ -1,11 +1,72 @@
-# from tables.import_export.version_conversions.base import VersionConverter
+from tables.import_export.version_conversions.base import VersionConverter
 
-# @VersionConverter.register(from_version=1)
-# def v1_to_v2(data: dict) -> dict:
-#     """
-#     Migrate from v1 to v2.
+_FIELD_TYPE_TO_VAR_TYPE = {
+    "llm_config": "integer",
+    "embedding_config": "integer",
+    "string": "string",
+    "boolean": "boolean",
+    "any": "any",
+    "integer": "integer",
+    "float": "number",
+}
 
-#     (Describe what changed between versions.)
-#     """
-#     # apply transformation
-#     return data
+
+@VersionConverter.register(from_version=1)
+def v1_to_v2(data: dict) -> dict:
+    """
+    v1 → v2: replace args_schema + python_code_tool_config_fields on each
+    PythonCodeTool entry with a single `variables` list, mirroring DB
+    migration 0170_pythoncodetool_variables_drop_args_schema.
+
+    agent_input variables come from args_schema.properties;
+    user_input variables come from python_code_tool_config_fields records.
+    Bundles that carry no PythonCodeTool key (e.g. graph-only snapshots)
+    pass through unchanged.
+    """
+    for tool in data.get("PythonCodeTool", []):
+        variables = []
+
+        schema = tool.get("args_schema") or {}
+        properties = schema.get("properties", {})
+        required_names = set(schema.get("required", []))
+
+        for name, prop in properties.items():
+            var = {
+                "name": name,
+                "type": prop.get("type", "string"),
+                "description": prop.get("description", ""),
+                "default_value": prop.get("default", None),
+                "input_type": "agent_input",
+                "required": name in required_names,
+            }
+
+            if prop.get("properties"):
+                var["properties"] = prop["properties"]
+
+            if prop.get("required"):
+                var["required_properties"] = prop["required"]
+
+            if prop.get("items"):
+                var["items"] = prop["items"]
+
+            variables.append(var)
+
+        for field in tool.get("python_code_tool_config_fields", []):
+            variables.append(
+                {
+                    "name": field.get("name"),
+                    "type": _FIELD_TYPE_TO_VAR_TYPE.get(
+                        field.get("data_type"), "string"
+                    ),
+                    "description": field.get("description") or "",
+                    "default_value": None,
+                    "input_type": "user_input",
+                    "required": field.get("required", True),
+                }
+            )
+
+        tool["variables"] = variables
+        tool.pop("args_schema", None)
+        tool.pop("python_code_tool_config_fields", None)
+
+    return data

--- a/src/django_app/tables/import_export/version_conversions/convertions.py
+++ b/src/django_app/tables/import_export/version_conversions/convertions.py
@@ -1,12 +1,13 @@
+from src.shared.models import args_schema_to_variables
 from tables.import_export.version_conversions.base import VersionConverter
 
 _FIELD_TYPE_TO_VAR_TYPE = {
-    "llm_config": "integer",
-    "embedding_config": "integer",
+    "llm_config": "number",
+    "embedding_config": "number",
     "string": "string",
     "boolean": "boolean",
     "any": "any",
-    "integer": "integer",
+    "integer": "number",
     "float": "number",
 }
 
@@ -22,34 +23,13 @@ def v1_to_v2(data: dict) -> dict:
     user_input variables come from python_code_tool_config_fields records.
     Bundles that carry no PythonCodeTool key (e.g. graph-only snapshots)
     pass through unchanged.
+
+    JSON-schema "integer" types are normalized to "number" to match the
+    runtime VariableType enum, which has no integer variant. Nested
+    object/array schemas are recursively converted to NestedVariable shape.
     """
     for tool in data.get("PythonCodeTool", []):
-        variables = []
-
-        schema = tool.get("args_schema") or {}
-        properties = schema.get("properties", {})
-        required_names = set(schema.get("required", []))
-
-        for name, prop in properties.items():
-            var = {
-                "name": name,
-                "type": prop.get("type", "string"),
-                "description": prop.get("description", ""),
-                "default_value": prop.get("default", None),
-                "input_type": "agent_input",
-                "required": name in required_names,
-            }
-
-            if prop.get("properties"):
-                var["properties"] = prop["properties"]
-
-            if prop.get("required"):
-                var["required_properties"] = prop["required"]
-
-            if prop.get("items"):
-                var["items"] = prop["items"]
-
-            variables.append(var)
+        variables = args_schema_to_variables(tool.get("args_schema") or {})
 
         for field in tool.get("python_code_tool_config_fields", []):
             variables.append(

--- a/src/django_app/tables/management/commands/upload_tools.py
+++ b/src/django_app/tables/management/commands/upload_tools.py
@@ -6,6 +6,9 @@ from tables.models import PythonCodeTool, PythonCode
 import yaml
 from django.db import transaction
 from loguru import logger
+from src.shared.models import (
+    args_schema_to_variables as _shared_args_schema_to_variables,
+)
 
 
 @dataclass
@@ -78,26 +81,7 @@ def get_code_file(tool_path: Path, code_file_name: str) -> str:
 
 
 def args_schema_to_variables(args_schema: dict) -> list[dict]:
-    properties = args_schema.get("properties", {})
-    required_names = set(args_schema.get("required", []))
-    variables = []
-    for name, prop in properties.items():
-        var = {
-            "name": name,
-            "type": prop.get("type", "string"),
-            "description": prop.get("description", ""),
-            "default_value": prop.get("default", None),
-            "input_type": "agent_input",
-            "required": name in required_names,
-        }
-        if prop.get("properties"):
-            var["properties"] = prop["properties"]
-        if prop.get("required"):
-            var["required_properties"] = prop["required"]
-        if prop.get("items"):
-            var["item"] = prop["items"]
-        variables.append(var)
-    return variables
+    return _shared_args_schema_to_variables(args_schema)
 
 
 def create_or_update_python_tool(

--- a/src/django_app/tables/migrations/0170_pythoncodetool_variables_drop_args_schema.py
+++ b/src/django_app/tables/migrations/0170_pythoncodetool_variables_drop_args_schema.py
@@ -2,14 +2,51 @@ from django.db import migrations, models
 
 
 _FIELD_TYPE_TO_VAR_TYPE = {
-    "llm_config": "integer",
-    "embedding_config": "integer",
+    "llm_config": "number",
+    "embedding_config": "number",
     "string": "string",
     "boolean": "boolean",
     "any": "any",
-    "integer": "integer",
+    "integer": "number",
     "float": "number",
 }
+
+_PASSTHROUGH_TYPES = {"string", "number", "boolean", "object", "array", "any"}
+
+
+def _normalize_type(json_type) -> str:
+    if not json_type:
+        return "string"
+
+    if json_type == "integer":
+        return "number"
+
+    if json_type in _PASSTHROUGH_TYPES:
+        return json_type
+
+    return json_type
+
+
+def _json_schema_node_to_nested_variable(node: dict) -> dict:
+    normalized_type = _normalize_type(node.get("type"))
+
+    result = {
+        "type": normalized_type,
+        "description": node.get("description", ""),
+        "default_value": node.get("default", None),
+    }
+
+    if normalized_type == "object":
+        result["properties"] = {
+            key: _json_schema_node_to_nested_variable(value)
+            for key, value in node.get("properties", {}).items()
+        }
+        result["required_properties"] = node.get("required", [])
+
+    if normalized_type == "array":
+        result["item"] = _json_schema_node_to_nested_variable(node.get("items", {}))
+
+    return result
 
 
 def migrate_to_variables(apps, schema_editor):
@@ -21,25 +58,16 @@ def migrate_to_variables(apps, schema_editor):
         variables = []
 
         schema = tool.args_schema or {}
-        properties = schema.get("properties", {})
         required_names = set(schema.get("required", []))
 
-        for name, prop in properties.items():
-            var = {
+        for name, prop in schema.get("properties", {}).items():
+            variable = {
                 "name": name,
-                "type": prop.get("type", "string"),
-                "description": prop.get("description", ""),
-                "default_value": prop.get("default", None),
                 "input_type": "agent_input",
                 "required": name in required_names,
             }
-            if prop.get("properties"):
-                var["properties"] = prop["properties"]
-            if prop.get("required"):
-                var["required_properties"] = prop["required"]
-            if prop.get("items"):
-                var["items"] = prop["items"]
-            variables.append(var)
+            variable.update(_json_schema_node_to_nested_variable(prop))
+            variables.append(variable)
 
         for field in PythonCodeToolConfigField.objects.filter(tool=tool):
             variables.append(

--- a/src/django_app/tests/import_export_tests/test_version_conversions.py
+++ b/src/django_app/tests/import_export_tests/test_version_conversions.py
@@ -1,0 +1,312 @@
+"""
+Tests for v1→v2 import/export version conversion and the shared variable_conversion helper.
+
+These tests are pure dict-transform tests — no DB access required.
+"""
+
+import pytest
+
+from src.shared.models import variable_adapter
+from src.shared.models.variable_conversion import (
+    _normalize_type,
+    json_schema_node_to_nested_variable,
+    args_schema_to_variables,
+)
+from tables.import_export.version_conversions.convertions import v1_to_v2
+
+
+# ──────────────────────────────────────────
+# _normalize_type
+# ──────────────────────────────────────────
+
+
+class TestNormalizeType:
+    def test_integer_becomes_number(self):
+        assert _normalize_type("integer") == "number"
+
+    def test_none_becomes_string(self):
+        assert _normalize_type(None) == "string"
+
+    def test_empty_string_becomes_string(self):
+        assert _normalize_type("") == "string"
+
+    def test_passthrough_types(self):
+        for t in ("string", "number", "boolean", "object", "array", "any"):
+            assert _normalize_type(t) == t
+
+
+# ──────────────────────────────────────────
+# json_schema_node_to_nested_variable
+# ──────────────────────────────────────────
+
+
+class TestJsonSchemaNodeToNestedVariable:
+    def test_primitive_string(self):
+        node = {"type": "string", "description": "A name"}
+        result = json_schema_node_to_nested_variable(node)
+        assert result == {
+            "type": "string",
+            "description": "A name",
+            "default_value": None,
+        }
+
+    def test_integer_normalized_to_number(self):
+        node = {"type": "integer", "description": "A count", "default": 0}
+        result = json_schema_node_to_nested_variable(node)
+        assert result["type"] == "number"
+        assert result["default_value"] == 0
+
+    def test_nested_object_required_becomes_required_properties(self):
+        node = {
+            "type": "object",
+            "properties": {
+                "length": {"type": "number"},
+                "width": {"type": "number"},
+            },
+            "required": ["length", "width"],
+        }
+        result = json_schema_node_to_nested_variable(node)
+        assert result["type"] == "object"
+        assert result["required_properties"] == ["length", "width"]
+        assert "properties" in result
+        assert result["properties"]["length"]["type"] == "number"
+        assert result["properties"]["width"]["type"] == "number"
+        assert "required" not in result
+        assert "items" not in result
+
+    def test_array_items_becomes_item(self):
+        node = {
+            "type": "array",
+            "items": {"type": "string"},
+        }
+        result = json_schema_node_to_nested_variable(node)
+        assert result["type"] == "array"
+        assert result["item"] == {
+            "type": "string",
+            "description": "",
+            "default_value": None,
+        }
+        assert "items" not in result
+
+    def test_array_of_object_recursion(self):
+        node = {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": ["weight", "dimensions"],
+                "properties": {
+                    "make": {"type": "string"},
+                    "model": {"type": "string"},
+                    "weight": {
+                        "type": "number",
+                        "minimum": 0,
+                        "description": "Weight in kg.",
+                    },
+                    "dimensions": {
+                        "type": "object",
+                        "required": ["length", "width", "height"],
+                        "properties": {
+                            "width": {
+                                "type": "number",
+                                "minimum": 0,
+                                "description": "Max width: 3.0m.",
+                            },
+                            "height": {
+                                "type": "number",
+                                "minimum": 0,
+                                "description": "Max height: 3.85m.",
+                            },
+                            "length": {"type": "number", "minimum": 0},
+                        },
+                    },
+                },
+            },
+            "minItems": 1,
+        }
+        result = json_schema_node_to_nested_variable(node)
+
+        assert result["type"] == "array"
+        item = result["item"]
+        assert item["type"] == "object"
+        assert set(item["required_properties"]) == {"weight", "dimensions"}
+
+        dims = item["properties"]["dimensions"]
+        assert dims["type"] == "object"
+        assert set(dims["required_properties"]) == {"length", "width", "height"}
+        assert dims["properties"]["width"]["type"] == "number"
+        assert dims["properties"]["height"]["description"] == "Max height: 3.85m."
+
+        assert item["properties"]["weight"]["description"] == "Weight in kg."
+        assert item["properties"]["make"]["type"] == "string"
+
+    def test_no_extra_keys_on_primitive(self):
+        node = {"type": "boolean"}
+        result = json_schema_node_to_nested_variable(node)
+        assert set(result.keys()) == {"type", "description", "default_value"}
+
+
+# ──────────────────────────────────────────
+# v1_to_v2 converter — full bundle
+# ──────────────────────────────────────────
+
+_MACHINES_ARGS_SCHEMA = {
+    "type": "object",
+    "title": "ToolInputSchema",
+    "required": ["machines"],
+    "properties": {
+        "machines": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": ["weight", "dimensions"],
+                "properties": {
+                    "make": {"type": "string"},
+                    "model": {"type": "string"},
+                    "weight": {
+                        "type": "number",
+                        "minimum": 0,
+                        "description": "Weight in kg. Max order capacity is 30,000kg.",
+                    },
+                    "dimensions": {
+                        "type": "object",
+                        "required": ["length", "width", "height"],
+                        "properties": {
+                            "width": {
+                                "type": "number",
+                                "minimum": 0,
+                                "description": "Max width: 3.0m.",
+                            },
+                            "height": {
+                                "type": "number",
+                                "minimum": 0,
+                                "description": "Max height: 3.85m.",
+                            },
+                            "length": {"type": "number", "minimum": 0},
+                        },
+                    },
+                },
+            },
+            "minItems": 1,
+        }
+    },
+}
+
+_V1_BUNDLE = {
+    "PythonCodeTool": [
+        {
+            "name": "FlatStringTool",
+            "args_schema": {
+                "type": "object",
+                "required": ["query"],
+                "properties": {
+                    "query": {"type": "string", "description": "Search query"},
+                },
+            },
+            "python_code_tool_config_fields": [],
+        },
+        {
+            "name": "IntegerArgTool",
+            "args_schema": {
+                "type": "object",
+                "required": ["count"],
+                "properties": {
+                    "count": {"type": "integer", "description": "How many"},
+                },
+            },
+            "python_code_tool_config_fields": [],
+        },
+        {
+            "name": "SplitMachinesIntoOrders",
+            "args_schema": _MACHINES_ARGS_SCHEMA,
+            "python_code_tool_config_fields": [],
+        },
+        {
+            "name": "ToolWithConfigField",
+            "args_schema": {
+                "type": "object",
+                "required": [],
+                "properties": {},
+            },
+            "python_code_tool_config_fields": [
+                {
+                    "name": "api_key",
+                    "data_type": "string",
+                    "description": "The API key",
+                    "required": True,
+                }
+            ],
+        },
+    ]
+}
+
+
+class TestV1ToV2:
+    def _convert(self):
+        import copy
+
+        return v1_to_v2(copy.deepcopy(_V1_BUNDLE))
+
+    def test_args_schema_removed(self):
+        result = self._convert()
+        for tool in result["PythonCodeTool"]:
+            assert "args_schema" not in tool
+
+    def test_python_code_tool_config_fields_removed(self):
+        result = self._convert()
+        for tool in result["PythonCodeTool"]:
+            assert "python_code_tool_config_fields" not in tool
+
+    def test_flat_string_variable_validates(self):
+        result = self._convert()
+        tool = next(
+            t for t in result["PythonCodeTool"] if t["name"] == "FlatStringTool"
+        )
+        assert len(tool["variables"]) == 1
+        variable_adapter.validate_python(tool["variables"][0])
+
+    def test_integer_arg_normalizes_to_number_and_validates(self):
+        result = self._convert()
+        tool = next(
+            t for t in result["PythonCodeTool"] if t["name"] == "IntegerArgTool"
+        )
+        var = tool["variables"][0]
+        assert var["type"] == "number"
+        variable_adapter.validate_python(var)
+
+    def test_machines_array_of_object_validates(self):
+        result = self._convert()
+        tool = next(
+            t
+            for t in result["PythonCodeTool"]
+            if t["name"] == "SplitMachinesIntoOrders"
+        )
+        assert len(tool["variables"]) == 1
+        var = tool["variables"][0]
+        assert var["name"] == "machines"
+        assert var["type"] == "array"
+        assert var["required"] is True
+        assert var["input_type"] == "agent_input"
+        # must not raise
+        variable_adapter.validate_python(var)
+
+    def test_config_field_user_input_validates(self):
+        result = self._convert()
+        tool = next(
+            t for t in result["PythonCodeTool"] if t["name"] == "ToolWithConfigField"
+        )
+        assert len(tool["variables"]) == 1
+        var = tool["variables"][0]
+        assert var["input_type"] == "user_input"
+        assert var["name"] == "api_key"
+        variable_adapter.validate_python(var)
+
+    def test_all_variables_in_all_tools_validate(self):
+        result = self._convert()
+        for tool in result["PythonCodeTool"]:
+            for var in tool["variables"]:
+                variable_adapter.validate_python(var)
+
+    def test_bundle_without_python_code_tool_key_passes_through(self):
+        data = {"Flow": [{"id": 1}]}
+        result = v1_to_v2(data)
+        assert result == {"Flow": [{"id": 1}]}

--- a/src/shared/models/__init__.py
+++ b/src/shared/models/__init__.py
@@ -94,6 +94,11 @@ from .variables import (
     ArrayNestedVariable,
     NestedVariable,
 )
+from .variable_conversion import (
+    args_schema_to_variables,
+    json_schema_node_to_nested_variable,
+    _normalize_type,
+)
 
 __all__ = [
     # agents
@@ -185,4 +190,8 @@ __all__ = [
     "ObjectNestedVariable",
     "ArrayNestedVariable",
     "NestedVariable",
+    # variable_conversion
+    "args_schema_to_variables",
+    "json_schema_node_to_nested_variable",
+    "_normalize_type",
 ]

--- a/src/shared/models/variable_conversion.py
+++ b/src/shared/models/variable_conversion.py
@@ -1,0 +1,60 @@
+__all__ = [
+    "args_schema_to_variables",
+    "json_schema_node_to_nested_variable",
+    "_normalize_type",
+]
+
+_PASSTHROUGH_TYPES = {"string", "number", "boolean", "object", "array", "any"}
+
+
+def _normalize_type(json_type) -> str:
+    if not json_type:
+        return "string"
+
+    if json_type == "integer":
+        return "number"
+
+    if json_type in _PASSTHROUGH_TYPES:
+        return json_type
+
+    return json_type
+
+
+def json_schema_node_to_nested_variable(node: dict) -> dict:
+    normalized_type = _normalize_type(node.get("type"))
+
+    result = {
+        "type": normalized_type,
+        "description": node.get("description", ""),
+        "default_value": node.get("default", None),
+    }
+
+    if normalized_type == "object":
+        result["properties"] = {
+            key: json_schema_node_to_nested_variable(value)
+            for key, value in node.get("properties", {}).items()
+        }
+        result["required_properties"] = node.get("required", [])
+
+    if normalized_type == "array":
+        result["item"] = json_schema_node_to_nested_variable(node.get("items", {}))
+
+    return result
+
+
+def args_schema_to_variables(
+    args_schema: dict, input_type: str = "agent_input"
+) -> list[dict]:
+    required_names = set(args_schema.get("required", []))
+    variables = []
+
+    for name, prop in args_schema.get("properties", {}).items():
+        variable = {
+            "name": name,
+            "input_type": input_type,
+            "required": name in required_names,
+        }
+        variable.update(json_schema_node_to_nested_variable(prop))
+        variables.append(variable)
+
+    return variables


### PR DESCRIPTION
## Description

In tools was removed args_schema field and replaced with variables. This PR provides backwards compatibility for tools import from previous release.

## Checklist

- [x] I have signed the **Contributor License Agreement (CLA)**. The CLA bot will comment on this PR — comment `I have read the CLA Document and I hereby sign the CLA` to sign. **This PR cannot be merged until the CLA is signed.**
- [x] My code follows the project's style and conventions.
- [x] I have tested my changes.
- [x] I have updated documentation where needed.
