### PR TITLE
Fix/EST-3144: Graph Versioning with CDT and Schedule Trigger

### DIFF
--- a/src/django_app/tables/graph_versioning/constants.py
+++ b/src/django_app/tables/graph_versioning/constants.py
@@ -38,6 +38,8 @@ _GRAPH_RELATION_NAMES = (
     "audio_transcription_node_list",
     "start_node_list",
     "decision_table_node_list",
+    "classification_decision_table_node_list",
+    "schedule_trigger_node_list",
     "telegram_trigger_node_list",
     "end_node",
     "graph_note_list",

--- a/src/django_app/tests/graph_versioning_tests/test_manager.py
+++ b/src/django_app/tests/graph_versioning_tests/test_manager.py
@@ -620,3 +620,60 @@ def test_create_graph_from_snapshot_recreates_edge_with_remapped_node_ids(
     original_node_ids = {start_node.id, crew_node.id}
     assert new_edge.start_node_id not in original_node_ids
     assert new_edge.end_node_id not in original_node_ids
+
+
+# ---------------------------------------------------------------------------
+# Group H: regression — nodes missing from _GRAPH_RELATION_NAMES
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_restore_does_not_raise_integrity_error_for_classification_decision_table_node(
+    manager, graph
+):
+    """
+    Restore must not raise IntegrityError for ClassificationDecisionTableNode.
+
+    Before the fix, _wipe_graph_children() did not delete
+    classification_decision_table_node_list rows. The subsequent recreate
+    would violate unique_graph_node_name_for_classification_dt_node.
+    """
+    from tables.models import ClassificationDecisionTableNode
+
+    ClassificationDecisionTableNode.objects.create(
+        graph=graph,
+        node_name="classifier_node",
+    )
+    snapshot = manager.create_snapshot(graph)
+
+    # apply_snapshot_to_graph is the restore path: wipe + recreate
+    manager.apply_snapshot_to_graph(graph, snapshot, available_deps={})
+
+    assert graph.classification_decision_table_node_list.count() == 1
+    restored = graph.classification_decision_table_node_list.first()
+    assert restored.node_name == "classifier_node"
+
+
+@pytest.mark.django_db
+def test_restore_does_not_duplicate_schedule_trigger_node(manager, graph):
+    """
+    Restore must not accumulate duplicate ScheduleTriggerNode rows.
+
+    Before the fix, _wipe_graph_children() silently skipped
+    schedule_trigger_node_list, so each restore appended new rows
+    without removing the old ones.
+    """
+    from tables.models import ScheduleTriggerNode
+
+    ScheduleTriggerNode.objects.create(
+        graph=graph,
+        node_name="trigger_node",
+        is_active=False,
+    )
+    assert graph.schedule_trigger_node_list.count() == 1
+
+    snapshot = manager.create_snapshot(graph)
+
+    manager.apply_snapshot_to_graph(graph, snapshot, available_deps={})
+
+    assert graph.schedule_trigger_node_list.count() == 1


### PR DESCRIPTION
…e and restore

## Description

Restoring a saved graph version failed when the graph contained a Classification Decision Table node and silently created duplicate Schedule Trigger nodes.

  During restore, GraphVersioningManager._wipe_graph_children() deletes a graph's existing child nodes by iterating over the _GRAPH_RELATION_NAMES tuple. That tuple was missing two
  reverse-relation names that exist on the models: classification_decision_table_node_list and schedule_trigger_node_list. As a result those nodes were never wiped before the snapshot
  was re-applied, so:

  - ClassificationDecisionTableNode hit its UniqueConstraint(graph, node_name) on re-creation → IntegrityError → restore failed.
  - ScheduleTriggerNode (no unique constraint) accumulated duplicate rows.

  This PR adds both relation names to _GRAPH_RELATION_NAMES, so existing nodes of these types are correctly removed before the version snapshot is recreated. No model or migration
  changes are required.

  Test plan

  - Save a version of a graph containing a Classification Decision Table node, then restore it → succeeds without IntegrityError; exactly one CDT node remains.
  - Save a version of a graph containing a Schedule Trigger node, then restore it → no duplicate nodes; count matches the original.


## Checklist

- [x] I have signed the **Contributor License Agreement (CLA)**. The CLA bot will comment on this PR — comment `I have read the CLA Document and I hereby sign the CLA` to sign. **This PR cannot be merged until the CLA is signed.**
- [x] My code follows the project's style and conventions.
- [x] I have tested my changes.
- [x] I have updated documentation where needed.
