### PR TITLE
fix(EST-3139-FE): replace native selects with app-select in Classification node

### DIFF
--- a/frontend/src/app/visual-programming/components/node-panels/classification-decision-table-node-panel/classification-decision-table-node-panel.component.html
+++ b/frontend/src/app/visual-programming/components/node-panels/classification-decision-table-node-panel/classification-decision-table-node-panel.component.html
@@ -27,15 +27,12 @@
                                 >Default Next Node
                                 <app-help-tooltip text="Fallback route when no condition matches" />
                             </label>
-                            <select
+                            <app-select
+                                label=""
+                                placeholder="Select Node"
                                 formControlName="default_next_node"
-                                class="header-select"
-                            >
-                                <option value="">Select Node</option>
-                                @for (node of availableNodes(); track node.value) {
-                                    <option [value]="node.value">{{ node.label }}</option>
-                                }
-                            </select>
+                                [items]="availableNodeItems()"
+                            />
                         </div>
 
                         <div class="header-field">
@@ -43,15 +40,12 @@
                                 >Error Next Node
                                 <app-help-tooltip text="Route taken if evaluation fails" />
                             </label>
-                            <select
+                            <app-select
+                                label=""
+                                placeholder="Select Node"
                                 formControlName="next_error_node"
-                                class="header-select"
-                            >
-                                <option value="">Select Node</option>
-                                @for (node of availableNodes(); track node.value) {
-                                    <option [value]="node.value">{{ node.label }}</option>
-                                }
-                            </select>
+                                [items]="availableNodeItems()"
+                            />
                         </div>
                     </div>
 

--- a/frontend/src/app/visual-programming/components/node-panels/classification-decision-table-node-panel/classification-decision-table-node-panel.component.scss
+++ b/frontend/src/app/visual-programming/components/node-panels/classification-decision-table-node-panel/classification-decision-table-node-panel.component.scss
@@ -102,27 +102,16 @@
     }
 }
 
-.header-select {
-    background: rgba(255, 255, 255, 0.06);
-    border: 1px solid rgba(255, 255, 255, 0.12);
-    border-radius: 6px;
-    color: #e0e0e0;
-    padding: 0.4rem 0.6rem;
-    font-size: 0.85rem;
-    box-sizing: border-box;
-    height: 32px;
+// Next-node dropdowns use the shared <app-select> (native <select> rendered
+// with broken OS-native styling on macOS). Size its trigger to match the
+// 32px header inputs so the three header columns stay aligned.
+.header-field app-select {
     width: 100%;
-    outline: none;
-    cursor: pointer;
-    transition: border-color 0.15s ease;
 
-    &:focus {
-        border-color: #685fff;
-    }
-
-    option {
-        background: #1a1a1a;
-        color: #fff;
+    ::ng-deep .selector__btn--default {
+        height: 32px;
+        font-size: 0.85rem;
+        padding: 0.4rem 2rem 0.4rem 0.6rem;
     }
 }
 

--- a/frontend/src/app/visual-programming/components/node-panels/classification-decision-table-node-panel/classification-decision-table-node-panel.component.scss
+++ b/frontend/src/app/visual-programming/components/node-panels/classification-decision-table-node-panel/classification-decision-table-node-panel.component.scss
@@ -102,9 +102,6 @@
     }
 }
 
-// Next-node dropdowns use the shared <app-select> (native <select> rendered
-// with broken OS-native styling on macOS). Size its trigger to match the
-// 32px header inputs so the three header columns stay aligned.
 .header-field app-select {
     width: 100%;
 

--- a/frontend/src/app/visual-programming/components/node-panels/classification-decision-table-node-panel/classification-decision-table-node-panel.component.ts
+++ b/frontend/src/app/visual-programming/components/node-panels/classification-decision-table-node-panel/classification-decision-table-node-panel.component.ts
@@ -12,6 +12,7 @@ import { ConfirmationDialogService } from '../../../../shared/components/cofirm-
 import { CustomInputComponent } from '../../../../shared/components/form-input/form-input.component';
 import { HelpTooltipComponent } from '../../../../shared/components/help-tooltip/help-tooltip.component';
 import { LlmModelSelectorComponent } from '../../../../shared/components/llm-model-selector/llm-model-selector.component';
+import { SelectComponent, SelectItem } from '../../../../shared/components/select/select.component';
 import { FullLLMConfig, FullLLMConfigService } from '../../../../shared/services/llms/full-llm-config.service';
 import { CodeEditorComponent } from '../../../../user-settings-page/tools/custom-tool-editor/code-editor/code-editor.component';
 import { NodeType } from '../../../core/enums/node-type';
@@ -43,6 +44,7 @@ type TabType = 'table' | 'precomputation' | 'postcomputation' | 'prompts';
         CodeEditorComponent,
         HelpTooltipComponent,
         AppSvgIconComponent,
+        SelectComponent,
     ],
     templateUrl: './classification-decision-table-node-panel.component.html',
     styleUrls: ['./classification-decision-table-node-panel.component.scss'],
@@ -157,11 +159,11 @@ export class ClassificationDecisionTableNodePanelComponent extends BaseSidePanel
             });
     }
 
-    public availableNodes = computed(() => {
+    public availableNodeItems = computed<SelectItem[]>(() => {
         const nodes = this.flowService.nodes();
         const currentNodeId = this.node().id;
 
-        return nodes
+        const nodeItems = nodes
             .filter(
                 (node) =>
                     node.type !== NodeType.NOTE &&
@@ -172,8 +174,10 @@ export class ClassificationDecisionTableNodePanelComponent extends BaseSidePanel
             )
             .map((node) => ({
                 value: node.id,
-                label: node.node_name || node.id,
+                name: node.node_name || node.id,
             }));
+
+        return [{ name: 'Select Node', value: '' }, ...nodeItems];
     });
 
     get activeColor(): string {


### PR DESCRIPTION

## Description

The Default/Error Next Node dropdowns used native <select> elements, which render with unstyled OS-native chrome on macOS (beveled gradient
+ chevrons) instead of the dark theme. Mirror the existing Decision Table fix: swap them for the shared <app-select> component, converting availableNodes -> availableNodeItems (SelectItem[]). Form values are unchanged (node id string, or '' for none), so save/autosave behave identically. 


## Checklist

- [x] I have signed the **Contributor License Agreement (CLA)**. The CLA bot will comment on this PR — comment `I have read the CLA Document and I hereby sign the CLA` to sign. **This PR cannot be merged until the CLA is signed.**
- [x] My code follows the project's style and conventions.
- [x] I have tested my changes.
- [x] I have updated documentation where needed.
