### PR TITLE
fix(AEPF-271): handle list-content in _strip_trailing_assistant for Claude 4.8

### DIFF
--- a/src/crew/tests/utils/test_llm_param_filtering.py
+++ b/src/crew/tests/utils/test_llm_param_filtering.py
@@ -3,7 +3,7 @@ import types
 import pytest
 
 from crewai.agent import temporary_temperature
-from src.crew.utils.llm_wrapper import PatchedLLM
+from src.crew.utils.llm_wrapper import PatchedLLM, _strip_trailing_assistant
 
 
 def _fake_stream():
@@ -125,3 +125,97 @@ def test_claude_4x_knowledge_path_never_sends_temperature(capture_completion):
     with temporary_temperature(llm, temp=0.0):
         llm.call("Reply with a single word: ok")
     assert "temperature" not in capture_completion
+
+
+# --- _strip_trailing_assistant (claude 4.x prefill handling) ---
+
+
+def test_strip_raises_on_empty_messages():
+    with pytest.raises(ValueError):
+        _strip_trailing_assistant([])
+
+
+def test_strip_noop_when_last_not_assistant():
+    messages = [{"role": "user", "content": "hi"}]
+    result = _strip_trailing_assistant(messages)
+    assert result == messages
+
+
+def test_strip_string_content_empty():
+    result = _strip_trailing_assistant([{"role": "assistant", "content": ""}])
+    assert result[-1]["role"] == "user"
+    assert (
+        result[-1]["content"]
+        == "Continue from where you left off and provide your response."
+    )
+    assert "partial progress" not in result[-1]["content"]
+
+
+def test_strip_string_content_nonempty():
+    result = _strip_trailing_assistant([{"role": "assistant", "content": "partial"}])
+    assert result[-1]["role"] == "user"
+    assert "partial progress" in result[-1]["content"]
+    assert "partial" in result[-1]["content"]
+
+
+def test_strip_list_text_only():
+    content = [{"type": "text", "text": "A"}, {"type": "text", "text": "B"}]
+    result = _strip_trailing_assistant([{"role": "assistant", "content": content}])
+    assert "A\nB" in result[-1]["content"]
+
+
+def test_strip_list_non_text_only():
+    content = [{"type": "image"}, {"type": "tool_use", "id": "x"}]
+    result = _strip_trailing_assistant([{"role": "assistant", "content": content}])
+    assert result[-1]["content"].count("[non-text content]") == 1
+
+
+def test_strip_list_mixed():
+    content = [
+        {"type": "text", "text": "A"},
+        {"type": "tool_use"},
+        {"type": "text", "text": "B"},
+    ]
+    result = _strip_trailing_assistant([{"role": "assistant", "content": content}])
+    assert "A\n[non-text content]\nB" in result[-1]["content"]
+
+
+def test_strip_list_empty_content():
+    result = _strip_trailing_assistant([{"role": "assistant", "content": []}])
+    assert result[-1]["role"] == "user"
+    assert (
+        result[-1]["content"]
+        == "Continue from where you left off and provide your response."
+    )
+    assert "partial progress" not in result[-1]["content"]
+
+
+def test_strip_preserves_prior_messages():
+    messages = [
+        {"role": "user", "content": "first"},
+        {"role": "assistant", "content": "second"},
+        {"role": "assistant", "content": "third"},
+    ]
+    result = _strip_trailing_assistant(messages)
+    assert result[0] == {"role": "user", "content": "first"}
+    assert result[1] == {"role": "assistant", "content": "second"}
+    assert result[-1]["role"] == "user"
+
+
+def test_strip_list_text_block_with_none_value():
+    """Text block with text=None must not raise — treated as empty string."""
+    messages = [{"role": "assistant", "content": [{"type": "text", "text": None}]}]
+    result = _strip_trailing_assistant(messages)
+    assert result[-1]["role"] == "user"
+    assert "partial progress" not in result[-1]["content"]
+
+
+def test_patched_llm_strips_list_content_before_completion(capture_completion):
+    messages = [
+        {"role": "user", "content": "Do the task."},
+        {"role": "assistant", "content": [{"type": "text", "text": "partial"}]},
+    ]
+    llm = PatchedLLM(model="claude-opus-4-8", api_key="test-key")
+    llm.call(messages)
+    assert capture_completion["messages"][-1]["role"] == "user"
+    assert "partial" in capture_completion["messages"][-1]["content"]

--- a/src/crew/utils/llm_wrapper.py
+++ b/src/crew/utils/llm_wrapper.py
@@ -40,11 +40,36 @@ def _model_drops_prefill(model: str | None) -> bool:
 
 
 def _strip_trailing_assistant(messages: list) -> list:
-    """Convert trailing assistant message to a user turn so Claude 4.x doesn't reject it."""
-    if not messages or messages[-1].get("role") != "assistant":
+    """Convert trailing assistant message to a user turn so Claude 4.x doesn't reject it.
+
+    Handles string content (preserved as-is) and list content (each block is extracted
+    as its text value or the marker "[non-text content]" for non-text blocks; a list that
+    contains no text blocks at all collapses to a single "[non-text content]" marker).
+    """
+    if not messages:
+        raise ValueError("_strip_trailing_assistant received an empty messages list")
+    if messages[-1].get("role") != "assistant":
         return messages
     msgs = list(messages)
-    prefill = msgs[-1].get("content") or ""
+    raw_content = msgs[-1].get("content")
+    if isinstance(raw_content, list):
+        if not raw_content:
+            prefill = ""
+        else:
+            parts = []
+            has_text = False
+            for block in raw_content:
+                if isinstance(block, dict) and block.get("type") == "text":
+                    parts.append(block.get("text") or "")
+                    has_text = True
+                else:
+                    parts.append("[non-text content]")
+            if not has_text:
+                prefill = "[non-text content]"
+            else:
+                prefill = "\n".join(parts)
+    else:
+        prefill = raw_content or ""
     msgs[-1] = {
         "role": "user",
         "content": (


### PR DESCRIPTION
## Summary

- Fixes latent bug in `_strip_trailing_assistant` where Anthropic multi-part list content (`[{"type":"text",...}]`) was not extracted correctly — raw list repr leaked into the recovery prompt instead of the actual text
- Empty `messages` list now raises `ValueError` instead of silently returning
- String content behaviour preserved exactly

## Root cause (AEPF-272)

`_strip_trailing_assistant` used `content or ""` which returns the list object when content is a non-empty list. The role was correctly changed to `user` (avoiding the API rejection), but the prefill text was garbage. A live reproduction script confirmed the real production error fires from unguarded `litellm.completion` call sites in `src/crew/libraries/` (out of scope), while the in-scope fix addresses the correctness gap on the guarded path.

## Changes

- `src/crew/utils/llm_wrapper.py` — `_strip_trailing_assistant` now iterates list content: text blocks → their text value, non-text blocks → `"[non-text content]"` marker, joined with `"\n"`; pure non-text list collapses to a single `"[non-text content]"` marker
- `src/crew/tests/utils/test_llm_param_filtering.py` — 11 new tests (9 unit + 1 integration via `PatchedLLM.call()`)

## Test plan

- [ ] `pytest src/crew/tests/utils/test_llm_param_filtering.py -v` — all new tests pass
- [ ] `pre-commit run --all-files` — ruff clean
- [ ] Reproduce script `reproduce_aepf271.py` — PATH A raises `AnthropicException`, PATH B succeeds