### PR TITLE
fix(EST-3241-BE): handle optional values in args schema and prevent None serialization in DotDict and DotList

### DIFF
--- a/src/crew/services/crew/tool_factories/args_schema_factory.py
+++ b/src/crew/services/crew/tool_factories/args_schema_factory.py
@@ -62,8 +62,11 @@ class ArgsSchemaFactory:
 
             default = cls._get_default(var.default_value, var.required)
             description = cls._compose_description(var.description, var)
+            py_type = var.python_type
+            if default is None and not var.required:
+                py_type = Optional[py_type]
             fields[var.name] = (
-                var.python_type,
+                py_type,
                 Field(default=default, description=description),
             )
         return fields

--- a/src/shared/dotdict/dotdict.py
+++ b/src/shared/dotdict/dotdict.py
@@ -118,7 +118,7 @@ class DotDict(dict):
                 values_schema=core_schema.any_schema(),
             ),
             serialization=core_schema.plain_serializer_function_ser_schema(
-                lambda v: v.deep_dump(),
+                lambda v: v.deep_dump() if v is not None else None,
                 return_schema=core_schema.dict_schema(),
             ),
         )
@@ -183,7 +183,7 @@ class DotList(list):
             cls._validate,
             core_schema.list_schema(items_schema=core_schema.any_schema()),
             serialization=core_schema.plain_serializer_function_ser_schema(
-                lambda v: v.deep_dump(),
+                lambda v: v.deep_dump() if v is not None else None,
                 return_schema=core_schema.list_schema(),
             ),
         )


### PR DESCRIPTION


Problem: Optional tool arguments (required=False) with no value failed validation. The field kept its bare type (e.g. str) while getting a None default, so Pydantic rejected the None/str mismatch. DotDict/DotList also crashed on None, since their serializers called .deep_dump() unconditionally.

Fix: Wrap the field type in Optional[...] when it's optional and defaults to None, and guard the DotDict/DotList serializers to return None instead of calling .deep_dump() on a None value.