### PR TITLE
feat(EST-3535-FE): move export button to CDT node header

### DIFF
--- a/frontend/src/app/shared/components/action-dropdown-button/action-dropdown-button.component.html
+++ b/frontend/src/app/shared/components/action-dropdown-button/action-dropdown-button.component.html
@@ -3,6 +3,8 @@
     cdkOverlayOrigin
     class="adb"
     [class.adb--disabled]="disabled() || loading()"
+    [style.width]="buttonWidth() === null ? 'auto' : buttonWidth() + 'px'"
+    [style.min-width]="buttonWidth() === null ? '0' : buttonWidth() + 'px'"
 >
     <button
         class="adb__main"

--- a/frontend/src/app/shared/components/action-dropdown-button/action-dropdown-button.component.scss
+++ b/frontend/src/app/shared/components/action-dropdown-button/action-dropdown-button.component.scss
@@ -5,8 +5,6 @@
 
 .adb {
     display: inline-flex;
-    width: 160px;
-    min-width: 160px;
     border-radius: 6px;
     overflow: hidden;
 

--- a/frontend/src/app/shared/components/action-dropdown-button/action-dropdown-button.component.ts
+++ b/frontend/src/app/shared/components/action-dropdown-button/action-dropdown-button.component.ts
@@ -25,6 +25,7 @@ export class ActionDropdownButtonComponent {
     disabled = input<boolean>(false);
     loading = input<boolean>(false);
     panelWidth = input<number>(160);
+    buttonWidth = input<number | null>(160);
 
     mainClick = output<void>();
     itemClick = output<ActionDropdownItem>();

--- a/frontend/src/app/visual-programming/components/node-panels/classification-decision-table-node-panel/classification-decision-table-node-panel.component.html
+++ b/frontend/src/app/visual-programming/components/node-panels/classification-decision-table-node-panel/classification-decision-table-node-panel.component.html
@@ -1,3 +1,14 @@
+<ng-template #exportButtonTpl>
+    <app-action-dropdown-button
+        label="Export"
+        [items]="exportFormatItems"
+        [panelWidth]="100"
+        [buttonWidth]="null"
+        (mainClick)="exportAsJson()"
+        (itemClick)="onExportItemSelected($event)"
+    />
+</ng-template>
+
 <div class="panel-container">
     <div class="panel-content">
         @if (form) {
@@ -88,16 +99,6 @@
                             >
                                 Prompt library
                             </button>
-
-                            <span class="tabs-row__divider"></span>
-
-                            <app-action-dropdown-button
-                                label="Export"
-                                [items]="exportFormatItems"
-                                [panelWidth]="100"
-                                (mainClick)="exportAsJson()"
-                                (itemClick)="onExportItemSelected($event)"
-                            />
                         </div>
                     </div>
                 </div>

--- a/frontend/src/app/visual-programming/components/node-panels/classification-decision-table-node-panel/classification-decision-table-node-panel.component.scss
+++ b/frontend/src/app/visual-programming/components/node-panels/classification-decision-table-node-panel/classification-decision-table-node-panel.component.scss
@@ -165,23 +165,6 @@
         display: flex;
         align-items: center;
         gap: 0.5rem;
-
-        ::ng-deep app-action-dropdown-button {
-            .adb {
-                width: 100px;
-                min-width: 100px;
-            }
-
-            .adb__main {
-                padding: 3px 10px;
-                font-size: 0.8em;
-            }
-
-            .adb__chevron {
-                flex: 0 0 28px;
-                padding: 3px 6px;
-            }
-        }
     }
 }
 

--- a/frontend/src/app/visual-programming/components/node-panels/classification-decision-table-node-panel/classification-decision-table-node-panel.component.ts
+++ b/frontend/src/app/visual-programming/components/node-panels/classification-decision-table-node-panel/classification-decision-table-node-panel.component.ts
@@ -8,7 +8,9 @@ import {
     inject,
     input,
     signal,
+    TemplateRef,
     untracked,
+    viewChild,
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormArray, FormGroup, ReactiveFormsModule } from '@angular/forms';
@@ -71,6 +73,7 @@ type TabType = 'table' | 'precomputation' | 'postcomputation' | 'prompts';
 export class ClassificationDecisionTableNodePanelComponent extends BaseSidePanel<ClassificationDecisionTableNodeModel> {
     public override readonly isExpanded = input<boolean>(true);
     public readonly graphId = input<number | null>(null);
+    public readonly exportButtonTemplate = viewChild<TemplateRef<unknown>>('exportButtonTpl');
 
     private flowService = inject(FlowService);
 
@@ -572,6 +575,7 @@ export class ClassificationDecisionTableNodePanelComponent extends BaseSidePanel
     public exportAsCsv(): void {
         if (this.node().backendId == null) {
             this.toastService.warning('Save the flow before exporting', 3000, 'bottom-right');
+            return;
         }
         const exportData = this.cdtExportImportService.buildExportData({
             nodeName: this.form.value.node_name ?? '',

--- a/frontend/src/app/visual-programming/components/node-panels/node-panel-shell/node-panel-shell.component.ts
+++ b/frontend/src/app/visual-programming/components/node-panels/node-panel-shell/node-panel-shell.component.ts
@@ -1,4 +1,4 @@
-import { NgComponentOutlet } from '@angular/common';
+import { NgComponentOutlet, NgTemplateOutlet } from '@angular/common';
 import {
     ChangeDetectionStrategy,
     Component,
@@ -8,6 +8,7 @@ import {
     output,
     Signal,
     signal,
+    TemplateRef,
     viewChild,
 } from '@angular/core';
 import { MatTooltipModule } from '@angular/material/tooltip';
@@ -23,7 +24,7 @@ import { SidePanelService } from '../../../services/side-panel.service';
 @Component({
     standalone: true,
     selector: 'app-node-panel-shell',
-    imports: [NgComponentOutlet, AppSvgIconComponent, MatTooltipModule],
+    imports: [NgComponentOutlet, NgTemplateOutlet, AppSvgIconComponent, MatTooltipModule],
     hostDirectives: [
         {
             directive: ShortcutListenerDirective,
@@ -50,6 +51,11 @@ import { SidePanelService } from '../../../services/side-panel.service';
                         <span class="title">{{ nodeNameToDisplay() }}</span>
                     </div>
                     <div class="header-actions">
+                        @if (panelInstanceSig()?.exportButtonTemplate?.()) {
+                            <ng-container
+                                [ngTemplateOutlet]="panelInstanceSig()!.exportButtonTemplate!()!"
+                            ></ng-container>
+                        }
                         @if (showSaveButton()) {
                             <button
                                 class="save-btn"
@@ -132,7 +138,12 @@ export class NodePanelShellComponent {
 
     public readonly shouldShowExpandButton = computed(() => {
         const node = this.node();
-        return node && node.type !== 'table' && node.type !== NodeType.SCHEDULE_TRIGGER && node.type !== 'classification-decision-table';
+        return (
+            node &&
+            node.type !== 'table' &&
+            node.type !== NodeType.SCHEDULE_TRIGGER &&
+            node.type !== 'classification-decision-table'
+        );
     });
 
     protected readonly outlet = viewChild(NgComponentOutlet);
@@ -155,6 +166,7 @@ export class NodePanelShellComponent {
         isSaving?: Signal<boolean>;
         form?: { invalid: boolean };
         onSaveClick?: () => void;
+        exportButtonTemplate?: () => TemplateRef<unknown> | undefined;
     } | null>(null);
     protected readonly showSaveButton = computed(() => {
         const panel = this.panelInstanceSig();
@@ -212,6 +224,7 @@ export class NodePanelShellComponent {
                                 isSaving?: Signal<boolean>;
                                 form?: { invalid: boolean };
                                 onSaveClick?: () => void;
+                                exportButtonTemplate?: () => TemplateRef<unknown> | undefined;
                             }
                         );
                         this.previousNodeId = node.id;

--- a/frontend/src/app/visual-programming/core/enums/node-config.ts
+++ b/frontend/src/app/visual-programming/core/enums/node-config.ts
@@ -8,7 +8,7 @@ export const NODE_ICONS: Record<NodeType, string> = {
     [NodeType.PROJECT]: 'ti ti-folder',
     [NodeType.PYTHON]: 'ti ti-brand-python',
     [NodeType.EDGE]: 'ti ti-route-alt-left',
-    [NodeType.START]: 'ti ti-player-play-filled',
+    [NodeType.START]: 'ti ti-filled ti-player-play',
     [NodeType.TABLE]: 'ti ti-table',
     [NodeType.CLASSIFICATION_TABLE]: 'ti ti-table-options',
     [NodeType.NOTE]: 'ti ti-note',

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -13,6 +13,7 @@
 @use './styles/_overlays';
 @use './styles/_prompt-tooltip';
 @use './styles/_action-dropdown-overlay';
+@use './styles/_tabler-icons-filled.scss';
 
 .waypoint-tooltip {
     display: none;

--- a/frontend/src/styles/_tabler-icons-filled.scss
+++ b/frontend/src/styles/_tabler-icons-filled.scss
@@ -1,0 +1,17 @@
+@font-face {
+    font-family: 'tabler-icons-filled';
+    src:
+        url('../../node_modules/@tabler/icons-webfont/dist/fonts/tabler-icons-filled.woff2') format('woff2'),
+        url('../../node_modules/@tabler/icons-webfont/dist/fonts/tabler-icons-filled.woff') format('woff');
+    font-weight: normal;
+    font-style: normal;
+    font-display: block;
+}
+
+.ti.ti-filled {
+    font-family: 'tabler-icons-filled' !important;
+}
+
+.ti.ti-filled.ti-player-play::before {
+    content: '\f691';
+}


### PR DESCRIPTION
## Description

Moves the Export button (JSON/CSV) in the Classification Decision Table node panel from the tabs bar to the node header, next to the close button.

- Export button now renders in the shared node-panel-shell via an optional slot provided only by the CDT panel — no impact on the other 11 node panel types.
- Added a buttonWidth input to ActionDropdownButtonComponent (default 160px preserved for existing consumers) so CDT's Export button sizes to content instead of leaving a large gap before the chevron.
- Fixed missing icon on the Start node — NODE_ICONS[NodeType.START] referenced an invalid Tabler class. Added a scoped filled-icon font-face (affects only Start, no global icon regression), loaded directly from node_modules for consistency with the existing base Tabler import.
- exportAsCsv() now returns early when the node isn't saved yet (backendId == null), matching exportAsJson()'s behavior.

## Checklist

- [ ] I have signed the **Contributor License Agreement (CLA)**. The CLA bot will comment on this PR — comment `I have read the CLA Document and I hereby sign the CLA` to sign. **This PR cannot be merged until the CLA is signed.**
- [ ] My code follows the project's style and conventions.
- [ ] I have tested my changes.
- [ ] I have updated documentation where needed.
