### PR TITLE
fix(EST-3549): make connections reassign correctly

### DIFF
--- a/frontend/src/app/visual-programming/flow-graph/flow-graph.component.ts
+++ b/frontend/src/app/visual-programming/flow-graph/flow-graph.component.ts
@@ -424,7 +424,7 @@ export class FlowGraphComponent implements OnInit, OnChanges, OnDestroy {
             !targetPort.multiple &&
             currentConnections.some((conn) => conn.targetPortId === pair.targetPortId);
         if (sourceOccupied || targetOccupied) {
-            console.warn('Single-use port already connected, ignoring:', `${pair.sourcePortId}+${pair.targetPortId}`);
+            this.toastService.warning('This port already has a connection', 4000, 'bottom-right');
             return;
         }
 

--- a/frontend/src/app/visual-programming/flow-graph/flow-graph.component.ts
+++ b/frontend/src/app/visual-programming/flow-graph/flow-graph.component.ts
@@ -412,6 +412,22 @@ export class FlowGraphComponent implements OnInit, OnChanges, OnDestroy {
             return;
         }
 
+        const allPorts = this.flowService.nodes().flatMap((n) => n.ports ?? []);
+        const sourcePort = allPorts.find((p) => p.id === pair.sourcePortId);
+        const targetPort = allPorts.find((p) => p.id === pair.targetPortId);
+        const sourceOccupied =
+            !!sourcePort &&
+            !sourcePort.multiple &&
+            currentConnections.some((conn) => conn.sourcePortId === pair.sourcePortId);
+        const targetOccupied =
+            !!targetPort &&
+            !targetPort.multiple &&
+            currentConnections.some((conn) => conn.targetPortId === pair.targetPortId);
+        if (sourceOccupied || targetOccupied) {
+            console.warn('Single-use port already connected, ignoring:', `${pair.sourcePortId}+${pair.targetPortId}`);
+            return;
+        }
+
         const sourceNodeId = pair.sourcePortId.split('_')[0];
         const targetNodeId = pair.targetPortId.split('_')[0];
 

--- a/frontend/src/app/visual-programming/services/flow.service.ts
+++ b/frontend/src/app/visual-programming/services/flow.service.ts
@@ -986,13 +986,6 @@ export class FlowService {
             // Start with an empty set so we don't include the port itself
             const eligible = new Set<CustomPortId>();
 
-            const currentConnCount = connectionCount[current.port.id] || 0;
-            if (!current.port.multiple && currentConnCount > 0) {
-                // If already connected and single-use, no allowed connections.
-                map[current.port.id] = ['__none__'];
-                return;
-            }
-
             allPorts.forEach((other) => {
                 // Skip self
                 if (current.port.id === other.port.id) return;


### PR DESCRIPTION
You couldn't drag a connection's end onto another node when the source port only allows one connection. Fixed how allowed connections are calculated so reassign works, while still preventing duplicate connections.

## Checklist

- [Х] I have signed the **Contributor License Agreement (CLA)**. The CLA bot will comment on this PR — comment `I have read the CLA Document and I hereby sign the CLA` to sign. **This PR cannot be merged until the CLA is signed.**
- [Х] My code follows the project's style and conventions.
- [Х] I have tested my changes.
- [Х] I have updated documentation where needed.
