### PR TITLE
fix: disable graph rag if cpu does not support avx2

### DIFF
--- a/src/knowledge/rag/graph_rag/exceptions.py
+++ b/src/knowledge/rag/graph_rag/exceptions.py
@@ -1,0 +1,2 @@
+class GraphRAGUnavailableError(RuntimeError):
+    """Raised when GraphRAG is requested on a host that can't run it."""

--- a/src/knowledge/rag/graph_rag/graph_rag_strategy.py
+++ b/src/knowledge/rag/graph_rag/graph_rag_strategy.py
@@ -5,19 +5,19 @@ from typing import Optional
 import pandas as pd
 from loguru import logger
 
-from graphrag.api.index import build_index
-from graphrag.api.query import basic_search, local_search
 from graphrag.config.models.graph_rag_config import GraphRagConfig
 
 from rag.base_rag_strategy import BaseRAGStrategy
 from rag.graph_rag.graph_rag_file_manager import GraphRagFileManager
 from rag.graph_rag.graph_rag_config_builder import GraphRagConfigBuilder
+from rag.graph_rag.exceptions import GraphRAGUnavailableError
 from src.shared.models import (
     GraphRagSearchConfig,
     BaseKnowledgeSearchMessageResponse,
     KnowledgeChunkResponse,
 )
 from settings import UnitOfWork
+from utils.cpu_features import supports_avx2
 
 
 class GraphRAGStrategy(BaseRAGStrategy):
@@ -42,7 +42,16 @@ class GraphRAGStrategy(BaseRAGStrategy):
         Args:
             base_dir: Optional base directory for graph data storage.
                      Defaults to <project>/src/knowledge/graph_data
+
+        Raises:
+            GraphRAGUnavailableError: If the host CPU lacks AVX2 support,
+                which lancedb (used internally by graphrag) requires.
         """
+        if not supports_avx2():
+            raise GraphRAGUnavailableError(
+                "GraphRAG is unavailable: this host's CPU lacks AVX2 support required by lancedb."
+            )
+
         self.file_manager = GraphRagFileManager(base_dir=base_dir)
         self.config_builder = GraphRagConfigBuilder()
 
@@ -181,6 +190,9 @@ class GraphRAGStrategy(BaseRAGStrategy):
         Args:
             config: GraphRagConfig instance
         """
+        # Deferred: keeps this module importable on CPUs without AVX2 (lancedb requires AVX2)
+        from graphrag.api.index import build_index
+
         # GraphRAG's build_index is async
         asyncio.run(build_index(config))
 
@@ -304,6 +316,9 @@ class GraphRAGStrategy(BaseRAGStrategy):
         query: str,
     ) -> tuple:
         """Run basic search using text_units only."""
+        # Deferred: keeps this module importable on CPUs without AVX2 (lancedb requires AVX2)
+        from graphrag.api.query import basic_search
+
         text_units = self._load_parquet(root_folder, "text_units.parquet")
         return asyncio.run(
             basic_search(
@@ -323,6 +338,9 @@ class GraphRAGStrategy(BaseRAGStrategy):
         Run local search using entities, communities, community_reports,
         text_units, relationships, and optional covariates.
         """
+        # Deferred: keeps this module importable on CPUs without AVX2 (lancedb requires AVX2)
+        from graphrag.api.query import local_search
+
         text_units = self._load_parquet(root_folder, "text_units.parquet")
         entities = self._load_parquet(root_folder, "entities.parquet")
         communities = self._load_parquet(root_folder, "communities.parquet")

--- a/src/knowledge/rag/rag_strategy_factory.py
+++ b/src/knowledge/rag/rag_strategy_factory.py
@@ -1,10 +1,6 @@
 from rag.base_rag_strategy import BaseRAGStrategy
 from rag.naive_rag_strategy import NaiveRAGStrategy
-from utils.cpu_features import supports_avx2
-
-
-class GraphRAGUnavailableError(RuntimeError):
-    """Raised when GraphRAG is requested on a host that can't run it."""
+from rag.graph_rag.graph_rag_strategy import GraphRAGStrategy
 
 
 class RAGStrategyFactory:
@@ -17,20 +13,9 @@ class RAGStrategyFactory:
     @classmethod
     def get_strategy(cls, rag_type: str):
         if rag_type == "graph" and rag_type not in cls._strategies:
-            cls._strategies[rag_type] = cls._create_graph_rag_strategy()
+            cls._strategies[rag_type] = GraphRAGStrategy()
 
         if rag_type not in cls._strategies:
             raise ValueError(f"Unsupported RAG type: {rag_type}")
 
         return cls._strategies[rag_type]
-
-    @staticmethod
-    def _create_graph_rag_strategy():
-        if not supports_avx2():
-            raise GraphRAGUnavailableError(
-                "GraphRAG is unavailable: this host's CPU lacks AVX2 support required by lancedb."
-            )
-
-        from rag.graph_rag.graph_rag_strategy import GraphRAGStrategy
-
-        return GraphRAGStrategy()

--- a/src/knowledge/rag/rag_strategy_factory.py
+++ b/src/knowledge/rag/rag_strategy_factory.py
@@ -6,16 +6,14 @@ from rag.graph_rag.graph_rag_strategy import GraphRAGStrategy
 class RAGStrategyFactory:
     """Factory for selecting correct RAG strategy by type."""
 
-    _strategies: dict[str, BaseRAGStrategy] = {
-        "naive": NaiveRAGStrategy(),
+    _strategies: dict[str, type[BaseRAGStrategy]] = {
+        "naive": NaiveRAGStrategy,
+        "graph": GraphRAGStrategy,
     }
 
     @classmethod
-    def get_strategy(cls, rag_type: str):
-        if rag_type == "graph" and rag_type not in cls._strategies:
-            cls._strategies[rag_type] = GraphRAGStrategy()
-
+    def get_strategy(cls, rag_type: str) -> BaseRAGStrategy:
         if rag_type not in cls._strategies:
             raise ValueError(f"Unsupported RAG type: {rag_type}")
 
-        return cls._strategies[rag_type]
+        return cls._strategies[rag_type]()

--- a/src/knowledge/rag/rag_strategy_factory.py
+++ b/src/knowledge/rag/rag_strategy_factory.py
@@ -1,17 +1,36 @@
+from rag.base_rag_strategy import BaseRAGStrategy
 from rag.naive_rag_strategy import NaiveRAGStrategy
-from rag.graph_rag.graph_rag_strategy import GraphRAGStrategy
+from utils.cpu_features import supports_avx2
+
+
+class GraphRAGUnavailableError(RuntimeError):
+    """Raised when GraphRAG is requested on a host that can't run it."""
 
 
 class RAGStrategyFactory:
     """Factory for selecting correct RAG strategy by type."""
 
-    _strategies = {
+    _strategies: dict[str, BaseRAGStrategy] = {
         "naive": NaiveRAGStrategy(),
-        "graph": GraphRAGStrategy(),
     }
 
     @classmethod
     def get_strategy(cls, rag_type: str):
+        if rag_type == "graph" and rag_type not in cls._strategies:
+            cls._strategies[rag_type] = cls._create_graph_rag_strategy()
+
         if rag_type not in cls._strategies:
             raise ValueError(f"Unsupported RAG type: {rag_type}")
+
         return cls._strategies[rag_type]
+
+    @staticmethod
+    def _create_graph_rag_strategy():
+        if not supports_avx2():
+            raise GraphRAGUnavailableError(
+                "GraphRAG is unavailable: this host's CPU lacks AVX2 support required by lancedb."
+            )
+
+        from rag.graph_rag.graph_rag_strategy import GraphRAGStrategy
+
+        return GraphRAGStrategy()

--- a/src/knowledge/utils/cpu_features.py
+++ b/src/knowledge/utils/cpu_features.py
@@ -1,0 +1,24 @@
+from loguru import logger
+
+CPUINFO_PATH = "/proc/cpuinfo"
+
+
+def supports_avx2() -> bool:
+    """
+    Check whether the host CPU advertises AVX2 support via /proc/cpuinfo.
+
+    Defaults to True (fail open) if the file can't be read or parsed, e.g.
+    on non-Linux dev environments. This check must never import `lancedb`
+    or `graphrag` — it exists specifically to be safe to call before those
+    modules are touched.
+    """
+    try:
+        with open(CPUINFO_PATH, "r") as cpuinfo_file:
+            for line in cpuinfo_file:
+                if line.startswith("flags"):
+                    return "avx2" in line.split(":", 1)[1].split()
+
+        return False
+    except Exception as e:
+        logger.warning("Could not determine AVX2 support, defaulting to True: {}", e)
+        return True


### PR DESCRIPTION
## Description

If AVX2 instructions are not supported, only naive rag will be available.

## Checklist

- [x] I have signed the **Contributor License Agreement (CLA)**. The CLA bot will comment on this PR — comment `I have read the CLA Document and I hereby sign the CLA` to sign. **This PR cannot be merged until the CLA is signed.**
- [x] My code follows the project's style and conventions.
- [x] I have tested my changes.
- [x] I have updated documentation where needed.
