### PR TITLE
fix(EST-3515): create_by field fix while import

### DIFF
--- a/src/django_app/tables/import_export/serializers/agent.py
+++ b/src/django_app/tables/import_export/serializers/agent.py
@@ -23,6 +23,7 @@ class AgentImportSerializer(serializers.ModelSerializer):
         exclude = [
             "tags",
             "knowledge_collection",
+            "created_by",
         ]
 
     def to_representation(self, instance):

--- a/src/django_app/tables/import_export/serializers/agent.py
+++ b/src/django_app/tables/import_export/serializers/agent.py
@@ -24,6 +24,7 @@ class AgentImportSerializer(serializers.ModelSerializer):
             "tags",
             "knowledge_collection",
             "created_by",
+            "org",
         ]
 
     def to_representation(self, instance):

--- a/src/django_app/tables/import_export/serializers/configs.py
+++ b/src/django_app/tables/import_export/serializers/configs.py
@@ -23,7 +23,7 @@ class BaseConfigImportSerializer(serializers.ModelSerializer):
     class Meta:
         abstract = True
         model = None
-        fields = "__all__"
+        exclude = ["created_by"]
 
     def get_fields(self):
         fields = super().get_fields()

--- a/src/django_app/tables/import_export/serializers/crew.py
+++ b/src/django_app/tables/import_export/serializers/crew.py
@@ -35,7 +35,7 @@ class CrewImportSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Crew
-        exclude = ["tags", "created_by"]
+        exclude = ["tags", "created_by", "org"]
 
     def to_representation(self, instance):
         ret = super().to_representation(instance)

--- a/src/django_app/tables/import_export/serializers/crew.py
+++ b/src/django_app/tables/import_export/serializers/crew.py
@@ -35,7 +35,7 @@ class CrewImportSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Crew
-        exclude = ["tags"]
+        exclude = ["tags", "created_by"]
 
     def to_representation(self, instance):
         ret = super().to_representation(instance)

--- a/src/django_app/tables/import_export/serializers/graph.py
+++ b/src/django_app/tables/import_export/serializers/graph.py
@@ -257,7 +257,14 @@ class GraphImportSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Graph
-        exclude = ["tags", "created_at", "updated_at", "labels", "save_version"]
+        exclude = [
+            "tags",
+            "created_at",
+            "updated_at",
+            "labels",
+            "save_version",
+            "created_by",
+        ]
 
 
 class ScheduleTriggerNodeImportSerializer(BaseNodeImportSerializer):

--- a/src/django_app/tables/import_export/serializers/llm_models.py
+++ b/src/django_app/tables/import_export/serializers/llm_models.py
@@ -42,7 +42,7 @@ class LLMModelImportSerializer(BaseModelImportSerializer):
 
     class Meta:
         model = LLMModel
-        exclude = ["llm_provider"]
+        exclude = ["llm_provider", "created_by"]
 
 
 class EmbeddingModelImportSerializer(BaseModelImportSerializer):
@@ -58,7 +58,7 @@ class EmbeddingModelImportSerializer(BaseModelImportSerializer):
 
     class Meta:
         model = EmbeddingModel
-        exclude = ["embedding_provider"]
+        exclude = ["embedding_provider", "created_by"]
 
 
 class RealtimeModelImportSerializer(BaseModelImportSerializer):
@@ -71,7 +71,7 @@ class RealtimeModelImportSerializer(BaseModelImportSerializer):
 
     class Meta:
         model = RealtimeModel
-        exclude = ["provider"]
+        exclude = ["provider", "created_by"]
 
 
 class RealtimeTranscriptionModelImportSerializer(BaseModelImportSerializer):
@@ -84,4 +84,4 @@ class RealtimeTranscriptionModelImportSerializer(BaseModelImportSerializer):
 
     class Meta:
         model = RealtimeTranscriptionModel
-        exclude = ["provider"]
+        exclude = ["provider", "created_by"]

--- a/src/django_app/tables/import_export/serializers/mcp_tools.py
+++ b/src/django_app/tables/import_export/serializers/mcp_tools.py
@@ -6,4 +6,4 @@ from tables.models import McpTool
 class McpToolImportSerializer(serializers.ModelSerializer):
     class Meta:
         model = McpTool
-        fields = "__all__"
+        exclude = ["created_by"]

--- a/src/django_app/tables/import_export/serializers/python_tools.py
+++ b/src/django_app/tables/import_export/serializers/python_tools.py
@@ -24,7 +24,7 @@ class PythonCodeToolConfigImportSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = PythonCodeToolConfig
-        exclude = ["id", "tool"]
+        exclude = ["id", "tool", "created_by"]
 
 
 class PythonCodeToolImportSerializer(serializers.ModelSerializer):
@@ -40,4 +40,4 @@ class PythonCodeToolImportSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = PythonCodeTool
-        exclude = ["favorite"]
+        exclude = ["favorite", "created_by"]

--- a/src/django_app/tables/import_export/services/import_service.py
+++ b/src/django_app/tables/import_export/services/import_service.py
@@ -23,6 +23,7 @@ class ImportService:
         main_entity: str,
         settings: ImportSettings = None,
         org_id: int = None,
+        user=None,
         effective_permissions=None,
     ):
         if settings is None:
@@ -50,6 +51,7 @@ class ImportService:
                         entity_type == main_entity,
                         settings=settings,
                         org_id=org_id,
+                        user=user,
                         effective_permissions=effective_permissions,
                     )
                     if denied is not None:
@@ -85,6 +87,7 @@ class ImportService:
         is_main,
         settings: ImportSettings = None,
         org_id=None,
+        user=None,
         effective_permissions=None,
         **kwargs,
     ):
@@ -105,6 +108,7 @@ class ImportService:
                 denied = resource
 
         kwargs["org_id"] = org_id
+        kwargs["user"] = user
 
         instance = strategy.import_entity(
             entity_data, id_mapper, is_main, settings=settings, **kwargs

--- a/src/django_app/tables/import_export/services/partial_import_service.py
+++ b/src/django_app/tables/import_export/services/partial_import_service.py
@@ -49,6 +49,7 @@ class PartialImportService:
         export_data: dict,
         graph: Graph,
         org_id: int = None,
+        user=None,
         effective_permissions=None,
     ) -> IDMapper:
         nodes_data = self._collect_nodes(export_data)
@@ -64,6 +65,7 @@ class PartialImportService:
                 export_data,
                 id_mapper,
                 org_id=org_id,
+                user=user,
                 effective_permissions=effective_permissions,
             )
 
@@ -92,6 +94,7 @@ class PartialImportService:
         export_data: dict,
         id_mapper: IDMapper,
         org_id: int = None,
+        user=None,
         effective_permissions=None,
     ) -> None:
         """Import all non-node, non-graph entity types in dependency order.
@@ -126,7 +129,7 @@ class PartialImportService:
                         denied_resources.add(resource)
 
                 instance = strategy.import_entity(
-                    entity_data, id_mapper, is_main=False, org_id=org_id
+                    entity_data, id_mapper, is_main=False, org_id=org_id, user=user
                 )
                 if instance is not None:
                     id_mapper.map(entity_type, old_id, instance.id, was_created)

--- a/src/django_app/tables/import_export/strategies/base.py
+++ b/src/django_app/tables/import_export/strategies/base.py
@@ -57,16 +57,29 @@ class EntityImportExportStrategy(ABC):
             existing = self.get_instance(existing_id)
             return existing
 
+        # The exported created_by references a user id from the source
+        # system; it may not exist here (e.g. its org was deleted), which
+        # would otherwise fail FK validation in create_entity. Drop it and
+        # stamp the importing user on the freshly created instance instead.
+        data = {k: v for k, v in data.items() if k != "created_by"}
+
         settings_kwargs = vars(settings) if settings is not None else {}
         create_kwargs = {**settings_kwargs, **kwargs}
         if is_main:
-            return self.create_entity(data, id_mapper, **create_kwargs)
+            instance = self.create_entity(data, id_mapper, **create_kwargs)
+        else:
+            existing = self.find_existing(data, id_mapper, org_id=kwargs.get("org_id"))
+            if existing:
+                return existing
 
-        existing = self.find_existing(data, id_mapper, org_id=kwargs.get("org_id"))
-        if existing:
-            return existing
+            instance = self.create_entity(data, id_mapper, **create_kwargs)
 
-        return self.create_entity(data, id_mapper, **create_kwargs)
+        user = kwargs.get("user")
+        if user is not None and hasattr(instance, "created_by_id"):
+            instance.created_by = user
+            instance.save(update_fields=["created_by"])
+
+        return instance
 
     def find_existing(
         self, data: dict, id_mapper: IDMapper, org_id: int = None

--- a/src/django_app/tables/services/import_export_service.py
+++ b/src/django_app/tables/services/import_export_service.py
@@ -67,6 +67,7 @@ class ViewSetImportExportService:
             self.entity_type,
             settings=settings,
             org_id=org_id,
+            user=user,
             effective_permissions=effective_permissions,
         )
         summary = id_mapper.get_detailed_summary(registry)

--- a/src/django_app/tables/views/model_view_sets.py
+++ b/src/django_app/tables/views/model_view_sets.py
@@ -969,6 +969,7 @@ class GraphViewSet(OrgScopedViewSetMixin, CopyActionMixin, viewsets.ModelViewSet
             export_data=data,
             graph=graph,
             org_id=org_id,
+            user=request.user,
             effective_permissions=effective_permissions,
         )
         summary = id_mapper.get_detailed_summary(entity_registry)


### PR DESCRIPTION
## Description

exclude create_by field from export in all entities that already have it (like: GraphImportSerializer, CrewImportSerializer, AgentImportSerializer, PythonCodeToolImportSerializer, McpToolImportSerializer, and BaseConfigImportSerializer add create_by field while import and attach it to current user

## Checklist

- [X] I have signed the **Contributor License Agreement (CLA)**. The CLA bot will comment on this PR — comment `I have read the CLA Document and I hereby sign the CLA` to sign. **This PR cannot be merged until the CLA is signed.**
- [x] My code follows the project's style and conventions.
- [x] I have tested my changes.
- [x] I have updated documentation where needed.
