### PR TITLE
fix(EST-3676): reduce noisy litellm/S3/redis-pubsub logging in django…

### DIFF
--- a/src/django_app/django_app/settings.py
+++ b/src/django_app/django_app/settings.py
@@ -60,6 +60,48 @@ LOGGING = {
         "handlers": ["loguru"],
         "level": "DEBUG",
     },
+    "loggers": {
+        "litellm": {
+            "handlers": ["loguru"],
+            "level": "WARNING",
+            "propagate": False,
+        },
+        "LiteLLM": {
+            "handlers": ["loguru"],
+            "level": "WARNING",
+            "propagate": False,
+        },
+        "LiteLLM Router": {
+            "handlers": ["loguru"],
+            "level": "WARNING",
+            "propagate": False,
+        },
+        "LiteLLM Proxy": {
+            "handlers": ["loguru"],
+            "level": "WARNING",
+            "propagate": False,
+        },
+        "boto3": {
+            "handlers": ["loguru"],
+            "level": "WARNING",
+            "propagate": False,
+        },
+        "botocore": {
+            "handlers": ["loguru"],
+            "level": "WARNING",
+            "propagate": False,
+        },
+        "s3transfer": {
+            "handlers": ["loguru"],
+            "level": "WARNING",
+            "propagate": False,
+        },
+        "urllib3": {
+            "handlers": ["loguru"],
+            "level": "WARNING",
+            "propagate": False,
+        },
+    },
 }
 
 

--- a/src/django_app/tables/services/redis_pubsub.py
+++ b/src/django_app/tables/services/redis_pubsub.py
@@ -85,7 +85,7 @@ class RedisPubSub:
 
     def session_status_handler(self, message: dict):
         try:
-            logger.debug(f"Received message from session_status_handler: {message}")
+            logger.debug("Received message from session_status_handler: {}", message)
             data = json.loads(message["data"])
             close_old_connections()
             with transaction.atomic():
@@ -126,7 +126,7 @@ class RedisPubSub:
 
     def code_results_handler(self, message: dict):
         try:
-            logger.debug(f"Received message from code_result_handler: {message}")
+            logger.debug("Received message from code_result_handler: {}", message)
             result = CodeResultData.model_validate_json(message["data"])
             close_old_connections()
             if not RunPythonCodeService().save_execution_result(result):
@@ -138,7 +138,7 @@ class RedisPubSub:
 
     def storage_mutations_handler(self, message: dict):
         try:
-            logger.debug(f"Received storage mutation event: {message}")
+            logger.debug("Received storage mutation event: {}", message)
             data = json.loads(message["data"])
             event = StorageMutationEvent.model_validate(data)
 
@@ -188,7 +188,7 @@ class RedisPubSub:
 
     def webhook_events_handler(self, message: dict):
         try:
-            logger.debug(f"Received webhook event: {message}")
+            logger.debug("Received webhook event: {}", message)
             data = WebhookEventData.model_validate_json(message["data"])
             if data.path.startswith(TELEGRAM_TRIGGER_PREFIX):
                 TelegramTriggerService().handle_telegram_trigger(
@@ -263,7 +263,10 @@ class RedisPubSub:
             with transaction.atomic():
                 created_objects = model.objects.bulk_create(data, ignore_conflicts=True)
                 logger.debug(
-                    f"{model.__name__} updated with {len(created_objects)}/{len(data)} entities"
+                    "{} updated with {}/{} entities",
+                    model.__name__,
+                    len(created_objects),
+                    len(data),
                 )
         except IntegrityError as e:
             logger.error(f"Failed to save {model.__name__}: {e}")
@@ -312,7 +315,7 @@ class RedisPubSub:
 
     def graph_session_message_handler(self, message: dict):
         try:
-            logger.info(f"Received message from graph_message_handler: {message}")
+            logger.debug("Received message from graph_message_handler: {}", message)
             data = json.loads(message["data"])
             graph_session_message_data = GraphSessionMessageData.model_validate(data)
             message_uuid = graph_session_message_data.uuid

--- a/src/django_app/tables/services/storage_service/s3_backend.py
+++ b/src/django_app/tables/services/storage_service/s3_backend.py
@@ -13,6 +13,7 @@ from tables.services.storage_service.dataclasses import (
     TreeNode,
     UploadResult,
 )
+from utils.logger import logger
 
 
 class S3StorageBackend(AbstractStorageBackend):
@@ -122,6 +123,7 @@ class S3StorageBackend(AbstractStorageBackend):
         full_path = self._full_path(path)
         self.client.upload_fileobj(file_object, self.bucket_name, full_path)
         head = self.client.head_object(Bucket=self.bucket_name, Key=full_path)
+        logger.info("Uploaded S3 object {}", full_path)
         return UploadResult(path=path, size=head["ContentLength"])
 
     def download(self, path: str) -> bytes:
@@ -141,6 +143,7 @@ class S3StorageBackend(AbstractStorageBackend):
         try:
             self.client.head_object(Bucket=self.bucket_name, Key=full_path)
             self.client.delete_object(Bucket=self.bucket_name, Key=full_path)
+            logger.info("Deleted S3 object {}", full_path)
             return
         except ClientError as error:
             if error.response["Error"]["Code"] != "404":
@@ -156,6 +159,9 @@ class S3StorageBackend(AbstractStorageBackend):
                     Bucket=self.bucket_name,
                     Delete={"Objects": objects},
                 )
+                logger.info(
+                    "Deleted {} S3 objects under prefix {}", len(objects), prefix
+                )
 
     def mkdir(self, path: str) -> None:
         full_path = self._full_path(path)
@@ -163,6 +169,7 @@ class S3StorageBackend(AbstractStorageBackend):
             full_path += "/"
         try:
             self.client.put_object(Bucket=self.bucket_name, Key=full_path, Body=b"")
+            logger.info("Created S3 folder {}", full_path)
         except ClientError as error:
             code = error.response["Error"]["Code"]
             if code in ("400", "XMinioInvalidObjectName"):
@@ -172,6 +179,7 @@ class S3StorageBackend(AbstractStorageBackend):
     def move(self, source_path: str, destination_path: str) -> None:
         self.copy(source_path, destination_path)
         self.delete(source_path)
+        logger.info("Moved S3 path {} to {}", source_path, destination_path)
 
     def rename(self, source_path: str, destination_path: str) -> None:
         full_source = self._full_path(source_path)
@@ -188,6 +196,7 @@ class S3StorageBackend(AbstractStorageBackend):
                 Key=full_destination,
             )
             self.client.delete_object(Bucket=self.bucket_name, Key=full_source)
+            logger.info("Renamed S3 object {} to {}", full_source, full_destination)
             return
 
         # Folder: map source_prefix/* -> destination_prefix/* (no extra nesting)
@@ -219,6 +228,7 @@ class S3StorageBackend(AbstractStorageBackend):
         self.client.delete_objects(
             Bucket=self.bucket_name, Delete={"Objects": keys_to_delete}
         )
+        logger.info("Renamed S3 prefix {} to {}", source_prefix, dest_prefix)
 
     def _key_exists(self, key: str, is_folder: bool) -> bool:
         if is_folder:


### PR DESCRIPTION
…_app

## Description

- Muted verbose DEBUG wire logging from litellm, boto3/botocore/s3transfer, urllib3 via WARNING overrides in settings.py LOGGING.
- Added concise INFO logs for mutating S3 actions in s3_backend.py to keep visibility after the mute.
- Converted f-string logs to loguru {} placeholders in redis_pubsub.py and downgraded the hottest handler to debug.

## Checklist

- [x] I have signed the **Contributor License Agreement (CLA)**. The CLA bot will comment on this PR — comment `I have read the CLA Document and I hereby sign the CLA` to sign. **This PR cannot be merged until the CLA is signed.**
- [x] My code follows the project's style and conventions.
- [x] I have tested my changes.
- [x] I have updated documentation where needed.
