### PR TITLE
fix(EST-3764-FE): make organization card clickable

### DIFF
--- a/frontend/src/app/features/role-base-access/components/org-card/org-card.component.html
+++ b/frontend/src/app/features/role-base-access/components/org-card/org-card.component.html
@@ -3,9 +3,6 @@
         <app-org-avatar [name]="organization().name" />
         <span class="name">{{ organization().name }}</span>
     </div>
-    <!--    <app-button mod="small" type="primary" class="open-btn" rightIcon="arrow-up-right" (click)="onOpen()">-->
-    <!--        Open-->
-    <!--    </app-button>-->
 </div>
 <div class="footer">
     <span class="org-users">{{ organization().member_count }} Users</span>

--- a/frontend/src/app/features/role-base-access/components/org-card/org-card.component.scss
+++ b/frontend/src/app/features/role-base-access/components/org-card/org-card.component.scss
@@ -3,6 +3,7 @@
     border-radius: 10px;
     display: flex;
     flex-direction: column;
+    cursor: pointer;
 }
 
 .header {

--- a/frontend/src/app/features/role-base-access/components/org-card/org-card.component.ts
+++ b/frontend/src/app/features/role-base-access/components/org-card/org-card.component.ts
@@ -1,7 +1,11 @@
-import { Dialog } from '@angular/cdk/dialog';
-import { ChangeDetectionStrategy, Component, DestroyRef, inject, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, input } from '@angular/core';
+import { Router } from '@angular/router';
 import { GetOrganizationResponse } from '@shared/models';
+import { EMPTY } from 'rxjs';
+import { catchError } from 'rxjs/operators';
 
+import { ProfileService } from '../../../../services/auth/profile.service';
+import { ToastService } from '../../../../services/notifications';
 import { OrgAvatarComponent } from '../org-avatar/org-avatar.component';
 
 @Component({
@@ -10,21 +14,30 @@ import { OrgAvatarComponent } from '../org-avatar/org-avatar.component';
     templateUrl: './org-card.component.html',
     styleUrls: ['./org-card.component.scss'],
     changeDetection: ChangeDetectionStrategy.OnPush,
+    host: {
+        '(click)': 'onOpen()',
+    },
 })
 export class OrgCardComponent {
-    private dialog = inject(Dialog);
-    private destroyRef = inject(DestroyRef);
+    private router = inject(Router);
+    private profileService = inject(ProfileService);
+    private toast = inject(ToastService);
 
     organization = input.required<GetOrganizationResponse>();
 
-    // onOpen(): void {
-    //     const id = this.organization().id;
-    //
-    //     this.dialog.open(OrganizationDetailsDialogComponent, {
-    //         width: 'calc(100vw - 2rem)',
-    //         height: 'calc(100vh - 2rem)',
-    //         disableClose: true,
-    //         data: { id },
-    //     });
-    // }
+    onOpen(): void {
+        const id = this.organization().id;
+
+        this.profileService
+            .switchOrg(id)
+            .pipe(
+                catchError((err) => {
+                    this.toast.error(err.error.message);
+                    return EMPTY;
+                })
+            )
+            .subscribe(() => {
+                this.router.navigateByUrl('/projects/my');
+            });
+    }
 }


### PR DESCRIPTION
## Description

The organization card in Workspace → Main was not clickable — a leftover `onOpen()` handler referenced a nonexistent `OrganizationDetailsDialogComponent` and was commented out, so clicking a card did nothing.

Clicking a card now switches the active organization to the one clicked (`ProfileService.switchOrg`) and navigates to `/projects/my`, reusing the same org-switching mechanism already used by the organization switcher in the user menu. The `X-Organization-Id` header (set by `activeOrgInterceptor` from the active org) then scopes the projects list to the clicked organization.

Removed the dead Dialog/OrganizationDetailsDialogComponent code path and the commented-out "Open" button.

## Checklist

- [ ] I have signed the **Contributor License Agreement (CLA)**. The CLA bot will comment on this PR — comment `I have read the CLA Document and I hereby sign the CLA` to sign. **This PR cannot be merged until the CLA is signed.**
- [ ] My code follows the project's style and conventions.
- [ ] I have tested my changes.
- [ ] I have updated documentation where needed.
