### PR TITLE
fix(EST-3765-FE): raise profile menu z-index above chat widget

### DIFF
--- a/frontend/src/app/features/role-base-access/components/user-sidebar-menu/user-menu.component.scss
+++ b/frontend/src/app/features/role-base-access/components/user-sidebar-menu/user-menu.component.scss
@@ -2,7 +2,9 @@
     position: absolute;
     bottom: 0;
     left: calc(100% + 8px);
-    z-index: 1000;
+    // Above the self-hosted "Virtual Assistant" chat widget bundle (public/epicchat-widget),
+    // whose panel/click-outside overlay use z-index 1002, so its popup would otherwise cover this menu.
+    z-index: 2000;
 }
 
 .user-menu-panel {


### PR DESCRIPTION
## Description

When the "Virtual Assistant" chat widget is open and the user opens the profile menu (bottom-left avatar), the chat widget's floating panel rendered on top of the profile menu, blocking "Workspace" / "My Profile" / "Sign out" from being clicked.

The chat widget is a separate self-hosted bundle (`public/epicchat-widget`) whose panel and click-outside overlay use `z-index: 1002`. The profile menu popup (`user-menu.component.scss`) used `z-index: 1000`, so it always lost. Raised it to `2000`. enough headroom above the widget's known values without needing to touch the widget itself.

## Checklist

- [ ] I have signed the **Contributor License Agreement (CLA)**. The CLA bot will comment on this PR — comment `I have read the CLA Document and I hereby sign the CLA` to sign. **This PR cannot be merged until the CLA is signed.**
- [ ] My code follows the project's style and conventions.
- [ ] I have tested my changes.
- [ ] I have updated documentation where needed.
