### PR TITLE
fix(EST-3766-FE): remove success toast on file move

### DIFF
--- a/frontend/src/app/features/files/pages/files-list-page/components/storage-page/storage-page.component.ts
+++ b/frontend/src/app/features/files/pages/files-list-page/components/storage-page/storage-page.component.ts
@@ -483,7 +483,6 @@ export class StoragePageComponent {
             .pipe(takeUntilDestroyed(this.destroyRef))
             .subscribe({
                 next: () => {
-                    this.toastService.success(`"${event.item.name}" moved`);
                     if (this.selectedFile()?.path === from) {
                         this.selectedFile.set({ ...event.item, path: to });
                     }


### PR DESCRIPTION
## Description

Moving a file or folder in Storage showed a success toast (`"<name>" moved`) for what's a routine, frequent action — noisy for the user.

Removed the `toastService.success(...)` call in `handleMove()` (`storage-page.component.ts`). This toast was isolated to the move handler only, so no other operation (delete/rename/copy) is affected. The error toast on a failed move is unchanged.

## Checklist

- [ ] I have signed the **Contributor License Agreement (CLA)**. The CLA bot will comment on this PR — comment `I have read the CLA Document and I hereby sign the CLA` to sign. **This PR cannot be merged until the CLA is signed.**
- [ ] My code follows the project's style and conventions.
- [ ] I have tested my changes.
- [ ] I have updated documentation where needed.
