### PR TITLE
fix(EST-3768-FE): stop folder navigation from closing file preview

### DIFF
--- a/frontend/src/app/features/files/pages/files-list-page/components/storage-page/components/storage-tree/storage-tree.component.ts
+++ b/frontend/src/app/features/files/pages/files-list-page/components/storage-page/components/storage-tree/storage-tree.component.ts
@@ -18,7 +18,6 @@ import { getFileExtension } from '../../../../../../utils/storage-file.utils';
 export class StorageTreeComponent {
     items = input<StorageItem[]>([]);
     fileSelected = output<StorageItem>();
-    folderSelected = output<StorageItem>();
     folderToggled = output<StorageItem>();
     contextAction = output<{
         action: string;
@@ -72,8 +71,6 @@ export class StorageTreeComponent {
         }
         if (item.type === 'file') {
             this.fileSelected.emit(item);
-        } else {
-            this.folderSelected.emit(item);
         }
     }
 

--- a/frontend/src/app/features/files/pages/files-list-page/components/storage-page/storage-page.component.html
+++ b/frontend/src/app/features/files/pages/files-list-page/components/storage-page/storage-page.component.html
@@ -16,7 +16,6 @@
                 <app-storage-tree
                     [items]="filteredTreeData()"
                     (fileSelected)="onFileSelect($event)"
-                    (folderSelected)="onFolderSelect()"
                     (folderToggled)="onFolderToggle($event)"
                     (contextAction)="onContextAction($event)"
                     (closeSidebar)="toggleSidebar()"

--- a/frontend/src/app/features/files/pages/files-list-page/components/storage-page/storage-page.component.html
+++ b/frontend/src/app/features/files/pages/files-list-page/components/storage-page/storage-page.component.html
@@ -16,7 +16,7 @@
                 <app-storage-tree
                     [items]="filteredTreeData()"
                     (fileSelected)="onFileSelect($event)"
-                    (folderSelected)="onFolderSelect($event)"
+                    (folderSelected)="onFolderSelect()"
                     (folderToggled)="onFolderToggle($event)"
                     (contextAction)="onContextAction($event)"
                     (closeSidebar)="toggleSidebar()"

--- a/frontend/src/app/features/files/pages/files-list-page/components/storage-page/storage-page.component.ts
+++ b/frontend/src/app/features/files/pages/files-list-page/components/storage-page/storage-page.component.ts
@@ -279,12 +279,11 @@ export class StoragePageComponent {
         this.setSelectedItem(item);
     }
 
-    onFolderSelect(item: StorageItem): void {
-        this.setSelectedItem(item);
+    onFolderSelect(): void {
+        // Selecting a folder in the tree must not affect an unrelated open file preview.
     }
 
     onFolderToggle(item: StorageItem): void {
-        this.selectedFile.set(null);
         if (item.isExpanded && (!item.children || item.children.length === 0)) {
             this.storageApiService
                 .list(item.path)

--- a/frontend/src/app/features/files/pages/files-list-page/components/storage-page/storage-page.component.ts
+++ b/frontend/src/app/features/files/pages/files-list-page/components/storage-page/storage-page.component.ts
@@ -279,10 +279,6 @@ export class StoragePageComponent {
         this.setSelectedItem(item);
     }
 
-    onFolderSelect(): void {
-        // Selecting a folder in the tree must not affect an unrelated open file preview.
-    }
-
     onFolderToggle(item: StorageItem): void {
         if (item.isExpanded && (!item.children || item.children.length === 0)) {
             this.storageApiService


### PR DESCRIPTION
## Description

Expanding/collapsing a folder or clicking a folder row in the Storage tree closed or replaced an already-open file preview, even though the user wasn't deselecting or selecting a different file.

Root cause: `storage-page.component.ts` reused a single `selectedFile` signal both for "the file shown in the preview panel" and as an incidental side-effect target of folder navigation. `onFolderToggle()` unconditionally cleared it (`selectedFile.set(null)`) on every expand/collapse, and `onFolderSelect()` overwrote it with the clicked folder.

Removed both side effects — folder navigation no longer touches `selectedFile`. Explicit file selection (`onFileSelect`) and the existing preview-sync logic on rename/move/delete of the previewed file are unchanged. Folder highlighting/selection in the tree itself is unaffected since it's tracked by `storage-tree.component.ts`'s own independent state.

## Checklist

- [ ] I have signed the **Contributor License Agreement (CLA)**. The CLA bot will comment on this PR — comment `I have read the CLA Document and I hereby sign the CLA` to sign. **This PR cannot be merged until the CLA is signed.**
- [ ] My code follows the project's style and conventions.
- [ ] I have tested my changes.
- [ ] I have updated documentation where needed.
