### PR TITLE
fix(EST-3769-FE): standardize empty folder indicator across folder trees

### DIFF
--- a/frontend/src/app/features/files/components/copy-to-dialog/copy-to-dialog.component.html
+++ b/frontend/src/app/features/files/components/copy-to-dialog/copy-to-dialog.component.html
@@ -75,6 +75,11 @@
                                         size="0.5rem"
                                     ></app-svg-icon>
                                 </span>
+                                <app-svg-icon
+                                    class="copy-to-dialog__node-icon"
+                                    icon="folder-storage"
+                                    size="12px"
+                                ></app-svg-icon>
                                 <span class="copy-to-dialog__node-name">/</span>
                             </div>
                             @for (node of visibleNodes(); track node.path) {
@@ -99,10 +104,21 @@
                                         <span class="copy-to-dialog__chevron-gap"></span>
                                     }
 
+                                    <app-svg-icon
+                                        class="copy-to-dialog__node-icon"
+                                        [class.copy-to-dialog__node-icon--empty]="node.isEmpty"
+                                        icon="folder-storage"
+                                        size="12px"
+                                    ></app-svg-icon>
+
                                     <span class="copy-to-dialog__node-name">{{ node.name }}</span>
 
                                     @if (node.isLoading) {
                                         <span class="copy-to-dialog__node-spinner">...</span>
+                                    }
+
+                                    @if (node.isEmpty) {
+                                        <span class="copy-to-dialog__empty-badge">Empty</span>
                                     }
                                 </div>
                             }

--- a/frontend/src/app/features/files/components/copy-to-dialog/copy-to-dialog.component.scss
+++ b/frontend/src/app/features/files/components/copy-to-dialog/copy-to-dialog.component.scss
@@ -223,6 +223,15 @@
         flex-shrink: 0;
     }
 
+    &__node-icon {
+        color: var(--text-secondary-60);
+        flex-shrink: 0;
+
+        &--empty {
+            opacity: 0.16;
+        }
+    }
+
     &__node-name {
         font-size: 0.875rem;
         color: var(--color-text-primary);
@@ -230,6 +239,17 @@
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
+    }
+
+    &__empty-badge {
+        flex-shrink: 0;
+        margin-left: auto;
+        padding-left: 0.75rem;
+        font-size: 0.875rem;
+        font-weight: 400;
+        color: var(--color-text-primary);
+        opacity: 0.16;
+        white-space: nowrap;
     }
 
     &__node-spinner {

--- a/frontend/src/app/features/files/components/copy-to-dialog/copy-to-dialog.component.ts
+++ b/frontend/src/app/features/files/components/copy-to-dialog/copy-to-dialog.component.ts
@@ -35,6 +35,7 @@ export interface FolderNode {
     hasChildren: boolean;
     children: FolderNode[];
     isLoaded: boolean;
+    isEmpty: boolean;
 }
 
 @Component({
@@ -153,6 +154,7 @@ export class CopyToDialogComponent {
                                 hasChildren: !i.is_empty,
                                 children: [],
                                 isLoaded: false,
+                                isEmpty: i.is_empty ?? false,
                             })
                         );
 

--- a/frontend/src/app/features/files/components/create-folder-dialog/create-folder-dialog.component.html
+++ b/frontend/src/app/features/files/components/create-folder-dialog/create-folder-dialog.component.html
@@ -102,6 +102,11 @@
                                             size="0.5rem"
                                         ></app-svg-icon>
                                     </span>
+                                    <app-svg-icon
+                                        class="create-folder-dialog__node-icon"
+                                        icon="folder-storage"
+                                        size="12px"
+                                    ></app-svg-icon>
                                     <span class="create-folder-dialog__node-name">/</span>
                                 </div>
                                 @for (node of visibleNodes(); track node.path) {
@@ -125,9 +130,18 @@
                                         } @else {
                                             <span class="create-folder-dialog__chevron-gap"></span>
                                         }
+                                        <app-svg-icon
+                                            class="create-folder-dialog__node-icon"
+                                            [class.create-folder-dialog__node-icon--empty]="node.isEmpty"
+                                            icon="folder-storage"
+                                            size="12px"
+                                        ></app-svg-icon>
                                         <span class="create-folder-dialog__node-name">{{ node.name }}</span>
                                         @if (node.isLoading) {
                                             <span class="create-folder-dialog__node-spinner">...</span>
+                                        }
+                                        @if (node.isEmpty) {
+                                            <span class="create-folder-dialog__empty-badge">Empty</span>
                                         }
                                     </div>
                                 }

--- a/frontend/src/app/features/files/components/create-folder-dialog/create-folder-dialog.component.scss
+++ b/frontend/src/app/features/files/components/create-folder-dialog/create-folder-dialog.component.scss
@@ -553,9 +553,29 @@
         flex-shrink: 0;
     }
 
+    &__node-icon {
+        color: var(--color-text-secondary);
+        flex-shrink: 0;
+
+        &--empty {
+            opacity: 0.16;
+        }
+    }
+
     &__node-name {
         font-size: 0.875rem;
         color: var(--color-text-primary);
+        white-space: nowrap;
+    }
+
+    &__empty-badge {
+        flex-shrink: 0;
+        margin-left: auto;
+        padding-left: 0.75rem;
+        font-size: 0.875rem;
+        font-weight: 400;
+        color: var(--color-text-primary);
+        opacity: 0.16;
         white-space: nowrap;
     }
 

--- a/frontend/src/app/features/files/components/create-folder-dialog/create-folder-dialog.component.ts
+++ b/frontend/src/app/features/files/components/create-folder-dialog/create-folder-dialog.component.ts
@@ -41,6 +41,7 @@ export interface FolderNode {
     hasChildren: boolean;
     children: FolderNode[];
     isLoaded: boolean;
+    isEmpty: boolean;
 }
 
 @Component({
@@ -300,6 +301,7 @@ export class CreateFolderDialogComponent {
                                 hasChildren: !i.is_empty,
                                 children: [],
                                 isLoaded: false,
+                                isEmpty: i.is_empty ?? false,
                             })
                         );
 

--- a/frontend/src/app/features/files/components/select-storage-files-dialog/select-storage-files-dialog.component.html
+++ b/frontend/src/app/features/files/components/select-storage-files-dialog/select-storage-files-dialog.component.html
@@ -114,6 +114,7 @@
 
                         <app-svg-icon
                             class="files-dialog__file-icon"
+                            [class.files-dialog__file-icon--empty]="node.type === 'folder' && node.is_empty"
                             [icon]="getFileIcon(node)"
                             size="12px"
                         ></app-svg-icon>
@@ -126,6 +127,10 @@
 
                         @if (node.isLoading) {
                             <span class="files-dialog__node-spinner">...</span>
+                        }
+
+                        @if (node.type === 'folder' && node.is_empty) {
+                            <span class="files-dialog__empty-badge">Empty</span>
                         }
 
                         @if (node.type === 'file' && node.size != null) {

--- a/frontend/src/app/features/files/components/select-storage-files-dialog/select-storage-files-dialog.component.scss
+++ b/frontend/src/app/features/files/components/select-storage-files-dialog/select-storage-files-dialog.component.scss
@@ -259,6 +259,10 @@
     &__file-icon {
         color: rgba(217, 217, 222, 0.6);
         flex-shrink: 0;
+
+        &--empty {
+            opacity: 0.16;
+        }
     }
 
     &__item-name {
@@ -266,6 +270,17 @@
         min-width: 0;
         font-size: 0.875rem;
         color: var(--color-text-primary);
+        white-space: nowrap;
+    }
+
+    &__empty-badge {
+        flex-shrink: 0;
+        margin-left: auto;
+        padding-left: 1rem;
+        font-size: 14px;
+        font-weight: 400;
+        color: var(--color-text-primary);
+        opacity: 0.16;
         white-space: nowrap;
     }
 

--- a/frontend/src/app/features/files/pages/files-list-page/components/storage-page/components/storage-tree/storage-tree.component.html
+++ b/frontend/src/app/features/files/pages/files-list-page/components/storage-page/components/storage-tree/storage-tree.component.html
@@ -69,6 +69,7 @@
             [attr.data-path]="node.path"
             [class.storage-tree__item--selected]="isItemSelected(node)"
             [class.storage-tree__item--non-empty]="node.type === 'folder' && !node.is_empty"
+            [class.storage-tree__item--empty]="node.type === 'folder' && node.is_empty"
             [class.storage-tree__item--hovered]="hoveredItem() === node"
             [class.storage-tree__item--drop-target]="isDropTarget(node)"
             [class.storage-tree__item--dragging]="draggedItem()?.path === node.path"

--- a/frontend/src/app/features/files/pages/files-list-page/components/storage-page/components/storage-tree/storage-tree.component.scss
+++ b/frontend/src/app/features/files/pages/files-list-page/components/storage-page/components/storage-tree/storage-tree.component.scss
@@ -142,6 +142,12 @@
             }
         }
 
+        &--empty {
+            .storage-tree__icon {
+                opacity: 0.16;
+            }
+        }
+
         &--selected {
             background-color: #685fff14;
             color: #685fff;
@@ -153,7 +159,8 @@
             }
 
             .storage-tree__empty-badge {
-                color: #685fff29;
+                color: var(--accent-color);
+                opacity: 0.16;
             }
 
             &:hover {
@@ -237,7 +244,8 @@
         letter-spacing: 0;
         text-align: right;
         vertical-align: middle;
-        color: var(--color-divider-subtle);
+        color: var(--color-text-primary);
+        opacity: 0.16;
         margin-left: 0;
         flex-shrink: 0;
     }


### PR DESCRIPTION
## Description

The "Empty" indicator for empty folders was inconsistent and incomplete:
- In the main Storage sidebar tree, the "Empty" text label worked, but the folder icon was never dimmed, and the badge's own opacity didn't match the intended 16% (≈8% in dark theme, fully opaque in light theme).
- The other three folder-tree pickers in the Files feature — "Copy to" dialog, "Create folder" destination picker, and the storage file-picker dialog — gave no visual cue for empty folders at all. The first two didn't even render folder icons.

Standardized the treatment across all four:
- **Main sidebar tree** (`storage-tree.component`): added an `--empty` modifier that dims the folder icon to 16% opacity, and switched the badge to `opacity: 0.16` on both default and selected states instead of hardcoded alpha hex values, so it's correct in both themes.
- **Storage file-picker dialog** (`select-storage-files-dialog`): it already tracked `is_empty` and rendered icons — added the same icon-dimming and "Empty" badge.
- **Copy to / Create folder dialogs**: these had no folder icons and didn't track emptiness at all. Added `isEmpty` to their `FolderNode` model (populated from the backend's `is_empty`), added a folder icon to every row, and the same dimmed-icon + "Empty" badge treatment for empty folders.

## Checklist

- [ ] I have signed the **Contributor License Agreement (CLA)**. The CLA bot will comment on this PR — comment `I have read the CLA Document and I hereby sign the CLA` to sign. **This PR cannot be merged until the CLA is signed.**
- [ ] My code follows the project's style and conventions.
- [ ] I have tested my changes.
- [ ] I have updated documentation where needed.
