### PR TITLE
fix(EST-3770-FE): sort folders before files in storage tree

### DIFF
--- a/frontend/src/app/features/files/components/select-storage-files-dialog/select-storage-files-dialog.component.ts
+++ b/frontend/src/app/features/files/components/select-storage-files-dialog/select-storage-files-dialog.component.ts
@@ -380,19 +380,21 @@ export class SelectStorageFilesDialogComponent {
             .pipe(takeUntilDestroyed(this.destroyRef))
             .subscribe({
                 next: (items) => {
-                    const nodes: TreeNode[] = items.map((i) => ({
-                        name: i.name,
-                        path: i.path || (path ? `${path}/${i.name}` : i.name),
-                        type: i.type,
-                        level: parent ? parent.level + 1 : 0,
-                        isExpanded: false,
-                        isLoading: false,
-                        hasChildren: i.type === 'folder' && !i.is_empty,
-                        children: [],
-                        isLoaded: false,
-                        is_empty: i.is_empty,
-                        size: i.size,
-                    }));
+                    const nodes: TreeNode[] = items
+                        .map((i) => ({
+                            name: i.name,
+                            path: i.path || (path ? `${path}/${i.name}` : i.name),
+                            type: i.type,
+                            level: parent ? parent.level + 1 : 0,
+                            isExpanded: false,
+                            isLoading: false,
+                            hasChildren: i.type === 'folder' && !i.is_empty,
+                            children: [],
+                            isLoaded: false,
+                            is_empty: i.is_empty,
+                            size: i.size,
+                        }))
+                        .sort(sortFoldersFirst);
 
                     if (parent) {
                         parent.children = nodes;
@@ -554,4 +556,9 @@ export class SelectStorageFilesDialogComponent {
             .replace(/"/g, '&quot;')
             .replace(/'/g, '&#39;');
     }
+}
+
+function sortFoldersFirst(a: TreeNode, b: TreeNode): number {
+    if (a.type !== b.type) return a.type === 'folder' ? -1 : 1;
+    return a.name.localeCompare(b.name);
 }

--- a/frontend/src/app/features/files/pages/files-list-page/components/storage-page/storage-page.component.ts
+++ b/frontend/src/app/features/files/pages/files-list-page/components/storage-page/storage-page.component.ts
@@ -269,10 +269,12 @@ export class StoragePageComponent {
     }
 
     private withPaths(items: StorageItem[], parentPath: string): StorageItem[] {
-        return items.map((item) => ({
-            ...item,
-            path: parentPath ? `${parentPath}/${item.name}` : item.name,
-        }));
+        return items
+            .map((item) => ({
+                ...item,
+                path: parentPath ? `${parentPath}/${item.name}` : item.name,
+            }))
+            .sort(sortFoldersFirst);
     }
 
     onFileSelect(item: StorageItem): void {
@@ -707,6 +709,11 @@ export class StoragePageComponent {
             .replace(/"/g, '&quot;')
             .replace(/'/g, '&#39;');
     }
+}
+
+function sortFoldersFirst(a: StorageItem, b: StorageItem): number {
+    if (a.type !== b.type) return a.type === 'folder' ? -1 : 1;
+    return a.name.localeCompare(b.name);
 }
 
 function filterStorageItems(items: StorageItem[], term: string): StorageItem[] {


### PR DESCRIPTION
## Description

Folders and files in Storage were shown in whatever order the backend `/storage/list/` endpoint returned them, so they appeared interleaved instead of folders being grouped above files.

Added a `sortFoldersFirst` comparator (folders before files, each group sorted alphabetically by name) and applied it:
- In `withPaths()` (`storage-page.component.ts`), the single choke point every tree load funnels through (root load, lazy-loaded folders, deep links, and reloads after move/rename/copy) — so the fix applies everywhere in the main Storage sidebar automatically.
- In `loadLevel()` (`select-storage-files-dialog.component.ts`, the "Add to flow" file picker), for consistency with the main tree.

## Checklist

- [ ] I have signed the **Contributor License Agreement (CLA)**. The CLA bot will comment on this PR — comment `I have read the CLA Document and I hereby sign the CLA` to sign. **This PR cannot be merged until the CLA is signed.**
- [ ] My code follows the project's style and conventions.
- [ ] I have tested my changes.
- [ ] I have updated documentation where needed.
