### PR TITLE
EST-3786: Cover EP: pythonnodes/<id>/last-session-input/ with permission

### DIFF
--- a/src/django_app/tables/views/views.py
+++ b/src/django_app/tables/views/views.py
@@ -1022,16 +1022,24 @@ class RegisterWebhooksApiView(APIView):
 
 
 class PythonNodeLastTestInputView(OrgScopedServiceViewSetMixin, APIView):
+    """
+    GET last tests input for python node from last
+    successfull session with that node
+    """
+
+    _PYTHONNODE_ORG_PATH = "graph__org_id"
+
     @extend_schema(**_LAST_TEST_INPUT_SWAGGER)
     def get(self, request, pk):
-        python_node = self.get_in_active_org_or_404(
-            PythonNode, pk, org_path="graph__org_id"
-        )
         assert_org_permission(
             request.user,
             self.get_active_org_id(),
             ResourceType.FLOWS,
             Permission.READ,
+        )
+
+        python_node = self.get_in_active_org_or_404(
+            PythonNode, pk, org_path=self._PYTHONNODE_ORG_PATH
         )
 
         python_node_name = f"{python_node.node_name} #{python_node.pk}"

--- a/src/django_app/tables/views/views.py
+++ b/src/django_app/tables/views/views.py
@@ -1021,13 +1021,18 @@ class RegisterWebhooksApiView(APIView):
         return Response(status=status.HTTP_200_OK)
 
 
-class PythonNodeLastTestInputView(APIView):
+class PythonNodeLastTestInputView(OrgScopedServiceViewSetMixin, APIView):
     @extend_schema(**_LAST_TEST_INPUT_SWAGGER)
     def get(self, request, pk):
-        try:
-            python_node = PythonNode.objects.get(pk=pk)
-        except PythonNode.DoesNotExist:
-            raise NotFound(detail="PythonNode not found.")
+        python_node = self.get_in_active_org_or_404(
+            PythonNode, pk, org_path="graph__org_id"
+        )
+        assert_org_permission(
+            request.user,
+            self.get_active_org_id(),
+            ResourceType.FLOWS,
+            Permission.READ,
+        )
 
         python_node_name = f"{python_node.node_name} #{python_node.pk}"
         found_input = (


### PR DESCRIPTION
## Description

Covers `pythonnodes/<id>/last-session-input/` endpoint with org check permission

## Checklist

- [x] I have signed the **Contributor License Agreement (CLA)**. The CLA bot will comment on this PR — comment `I have read the CLA Document and I hereby sign the CLA` to sign. **This PR cannot be merged until the CLA is signed.**
- [x] My code follows the project's style and conventions.
- [x] I have tested my changes.
- [x] I have updated documentation where needed.
