### PR TITLE
fix(EST-3705): enforce READ_ONLY at the DB connection level in natura…

### DIFF
--- a/src/shared/tools/natural_language_to_sql_tool/main.py
+++ b/src/shared/tools/natural_language_to_sql_tool/main.py
@@ -1,8 +1,14 @@
 # Natural Language To SQL Tool
 
+from sqlalchemy import create_engine, event
 from langchain_community.utilities import SQLDatabase
 from langchain_community.agent_toolkits import create_sql_agent
 from langchain_openai import ChatOpenAI
+
+READ_ONLY_SESSION_STATEMENTS = {
+    "postgresql": "SET SESSION CHARACTERISTICS AS TRANSACTION READ ONLY",
+    "mysql": "SET SESSION TRANSACTION READ ONLY",
+}
 
 
 class NaturalLanguageToSQLTool:
@@ -11,17 +17,36 @@ class NaturalLanguageToSQLTool:
         self.openai_api_key = state["variables"]["OPENAI_API_KEY"]
         self.read_only = state["variables"]["READ_ONLY"]
 
+    def _create_engine(self):
+        engine = create_engine(self.db_uri)
+
+        if self.read_only:
+            statement = READ_ONLY_SESSION_STATEMENTS.get(engine.dialect.name)
+            if statement is None:
+                raise RuntimeError(
+                    f"Read-only mode is not supported for the '{engine.dialect.name}' database dialect."
+                )
+
+            @event.listens_for(engine, "connect")
+            def _enforce_read_only(dbapi_connection, connection_record):
+                cursor = dbapi_connection.cursor()
+                cursor.execute(statement)
+                cursor.close()
+
+        return engine
+
     def _create_agent(self):
         # TODO chould we parametrize that? at least model?
         llm = ChatOpenAI(
             model="gpt-4o-mini", temperature=0, api_key=self.openai_api_key
         )
-        db = SQLDatabase.from_uri(self.db_uri)
+        engine = self._create_engine()
+        db = SQLDatabase(engine)
 
         crud_policy = (
             "You may execute SELECT, INSERT, UPDATE, DELETE, and DROP statements."
             if not self.read_only
-            else "You must NEVER execute INSERT, UPDATE, DELETE, or DROP statements. If the user asks to modify the database, just inform them that you are in read-only mode."
+            else "You are in read-only mode: the database connection itself rejects INSERT, UPDATE, DELETE, and DROP statements. If the user asks to modify the database, inform them that you are in read-only mode."
         )
 
         agent_executor = create_sql_agent(

--- a/src/shared/tools/natural_language_to_sql_tool/main.py
+++ b/src/shared/tools/natural_language_to_sql_tool/main.py
@@ -3,7 +3,7 @@
 from sqlalchemy import create_engine, event
 from langchain_community.utilities import SQLDatabase
 from langchain_community.agent_toolkits import create_sql_agent
-from langchain_openai import ChatOpenAI
+from langchain_litellm import ChatLiteLLM
 
 READ_ONLY_SESSION_STATEMENTS = {
     "postgresql": "SET SESSION CHARACTERISTICS AS TRANSACTION READ ONLY",
@@ -14,7 +14,15 @@ READ_ONLY_SESSION_STATEMENTS = {
 class NaturalLanguageToSQLTool:
     def __init__(self):
         self.db_uri = state["variables"]["DB_URI"]
-        self.openai_api_key = state["variables"]["OPENAI_API_KEY"]
+        self.model = state["variables"].get("MODEL") or "gpt-4o-mini"
+        self.api_key = state["variables"].get("API_KEY") or state["variables"].get(
+            "OPENAI_API_KEY"
+        )
+        if not self.api_key:
+            raise RuntimeError(
+                "No API key configured. Set the 'API_KEY' domain variable "
+                "(or 'OPENAI_API_KEY' for backward compatibility)."
+            )
         self.read_only = state["variables"]["READ_ONLY"]
 
     def _create_engine(self):
@@ -37,10 +45,7 @@ class NaturalLanguageToSQLTool:
         return engine
 
     def _create_agent(self):
-        # TODO chould we parametrize that? at least model?
-        llm = ChatOpenAI(
-            model="gpt-4o-mini", temperature=0, api_key=self.openai_api_key
-        )
+        llm = ChatLiteLLM(model=self.model, temperature=0, api_key=self.api_key)
         engine = self._create_engine()
         db = SQLDatabase(engine)
 

--- a/src/shared/tools/natural_language_to_sql_tool/main.py
+++ b/src/shared/tools/natural_language_to_sql_tool/main.py
@@ -32,6 +32,7 @@ class NaturalLanguageToSQLTool:
                 cursor = dbapi_connection.cursor()
                 cursor.execute(statement)
                 cursor.close()
+                dbapi_connection.commit()
 
         return engine
 

--- a/src/shared/tools/natural_language_to_sql_tool/requirements.txt
+++ b/src/shared/tools/natural_language_to_sql_tool/requirements.txt
@@ -1,6 +1,7 @@
-langchain_openai
 langchain_community
 langchain
+langchain-litellm
+litellm
 sqlalchemy
 psycopg2-binary
 pymysql

--- a/src/shared/tools/natural_language_to_sql_tool/requirements.txt
+++ b/src/shared/tools/natural_language_to_sql_tool/requirements.txt
@@ -1,5 +1,6 @@
 langchain_openai
 langchain_community
 langchain
+sqlalchemy
 psycopg2-binary
 pymysql

--- a/src/shared/tools/natural_language_to_sql_tool/tool_data.yaml
+++ b/src/shared/tools/natural_language_to_sql_tool/tool_data.yaml
@@ -1,6 +1,6 @@
 tool-data:
   name: "Natural Language To SQL Tool"
-  description: "A tool that converts natural language into SQL queries and executes them on the provided database.  Write your OpenAI API key and DB URI in the domain variables in the format {\"OPENAI_API_KEY\" = \"YOUR_SECRET_KEY\", \"DB_URI\" = \"YOUR_DB_URI\"}"
+  description: "A tool that converts natural language into SQL queries and executes them on the provided database. Configure it via domain variables: \"DB_URI\" (required), \"API_KEY\" (your LLM provider API key), and \"MODEL\" (optional, defaults to \"gpt-4o-mini\"). MODEL supports any LiteLLM-compatible provider that only needs a model name and API key, using the \"<provider>/<model>\" convention: a bare name means OpenAI (e.g. \"gpt-4o-mini\"), \"anthropic/claude-3-5-sonnet-20241022\" for Anthropic, \"gemini/gemini-1.5-pro\" for Gemini. (Providers requiring extra config, such as Azure OpenAI's endpoint/api-version, are not currently supported since only MODEL and API_KEY are wired through.) Example: {\"DB_URI\" = \"YOUR_DB_URI\", \"API_KEY\" = \"YOUR_SECRET_KEY\", \"MODEL\" = \"anthropic/claude-3-5-sonnet-20241022\"}. For backward compatibility, \"OPENAI_API_KEY\" is still accepted as a fallback if \"API_KEY\" is not set."
   args-schema: "args_schema.json"
   code-file: "main.py"
   entrypoint: "main"

--- a/src/shared/tools/tests/test_natural_language_to_sql_tool.py
+++ b/src/shared/tools/tests/test_natural_language_to_sql_tool.py
@@ -61,6 +61,7 @@ class TestNaturalLanguageToSQLToolReadOnlyPostgres:
             "SET SESSION CHARACTERISTICS AS TRANSACTION READ ONLY"
         )
         fake_cursor.close.assert_called_once()
+        fake_connection.commit.assert_called_once()
 
 
 class TestNaturalLanguageToSQLToolReadOnlyMySQL:
@@ -100,6 +101,7 @@ class TestNaturalLanguageToSQLToolReadOnlyMySQL:
 
         fake_cursor.execute.assert_called_once_with("SET SESSION TRANSACTION READ ONLY")
         fake_cursor.close.assert_called_once()
+        fake_connection.commit.assert_called_once()
 
 
 class TestNaturalLanguageToSQLToolUnsupportedDialect:

--- a/src/shared/tools/tests/test_natural_language_to_sql_tool.py
+++ b/src/shared/tools/tests/test_natural_language_to_sql_tool.py
@@ -1,0 +1,145 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from conftest import load_tool_main
+
+
+def _make_tool(module, db_uri: str, read_only: bool):
+    module.state = {
+        "variables": {
+            "DB_URI": db_uri,
+            "OPENAI_API_KEY": "sk-test",
+            "READ_ONLY": read_only,
+        }
+    }
+    return module.NaturalLanguageToSQLTool()
+
+
+def _fake_engine(dialect_name: str) -> MagicMock:
+    engine = MagicMock()
+    engine.dialect.name = dialect_name
+    return engine
+
+
+class TestNaturalLanguageToSQLToolReadOnlyPostgres:
+    def test_read_only_postgres_registers_listener_that_sets_read_only(self):
+        module = load_tool_main("natural_language_to_sql_tool")
+        tool = _make_tool(
+            module, "postgresql+psycopg2://user:pass@localhost/db", read_only=True
+        )
+        fake_engine = _fake_engine("postgresql")
+
+        captured_listener = {}
+
+        def fake_listens_for(target, identifier):
+            assert target is fake_engine
+            assert identifier == "connect"
+
+            def decorator(fn):
+                captured_listener["fn"] = fn
+                return fn
+
+            return decorator
+
+        with (
+            patch.object(module, "create_engine", return_value=fake_engine),
+            patch.object(module.event, "listens_for", side_effect=fake_listens_for),
+        ):
+            engine = tool._create_engine()
+
+        assert engine is fake_engine
+        assert "fn" in captured_listener
+
+        fake_cursor = MagicMock()
+        fake_connection = MagicMock()
+        fake_connection.cursor.return_value = fake_cursor
+
+        captured_listener["fn"](fake_connection, None)
+
+        fake_cursor.execute.assert_called_once_with(
+            "SET SESSION CHARACTERISTICS AS TRANSACTION READ ONLY"
+        )
+        fake_cursor.close.assert_called_once()
+
+
+class TestNaturalLanguageToSQLToolReadOnlyMySQL:
+    def test_read_only_mysql_registers_listener_that_sets_read_only(self):
+        module = load_tool_main("natural_language_to_sql_tool")
+        tool = _make_tool(
+            module, "mysql+pymysql://user:pass@localhost/db", read_only=True
+        )
+        fake_engine = _fake_engine("mysql")
+
+        captured_listener = {}
+
+        def fake_listens_for(target, identifier):
+            assert target is fake_engine
+            assert identifier == "connect"
+
+            def decorator(fn):
+                captured_listener["fn"] = fn
+                return fn
+
+            return decorator
+
+        with (
+            patch.object(module, "create_engine", return_value=fake_engine),
+            patch.object(module.event, "listens_for", side_effect=fake_listens_for),
+        ):
+            engine = tool._create_engine()
+
+        assert engine is fake_engine
+        assert "fn" in captured_listener
+
+        fake_cursor = MagicMock()
+        fake_connection = MagicMock()
+        fake_connection.cursor.return_value = fake_cursor
+
+        captured_listener["fn"](fake_connection, None)
+
+        fake_cursor.execute.assert_called_once_with("SET SESSION TRANSACTION READ ONLY")
+        fake_cursor.close.assert_called_once()
+
+
+class TestNaturalLanguageToSQLToolUnsupportedDialect:
+    def test_read_only_unsupported_dialect_raises_runtime_error(self):
+        module = load_tool_main("natural_language_to_sql_tool")
+        tool = _make_tool(module, "sqlite:///:memory:", read_only=True)
+        fake_engine = _fake_engine("sqlite")
+
+        with patch.object(module, "create_engine", return_value=fake_engine):
+            with pytest.raises(RuntimeError) as exc_info:
+                tool._create_engine()
+
+        assert "sqlite" in str(exc_info.value)
+
+
+class TestNaturalLanguageToSQLToolReadWrite:
+    def test_read_write_mode_registers_no_read_only_listener(self):
+        module = load_tool_main("natural_language_to_sql_tool")
+        tool = _make_tool(
+            module, "postgresql+psycopg2://user:pass@localhost/db", read_only=False
+        )
+        fake_engine = _fake_engine("postgresql")
+
+        with (
+            patch.object(module, "create_engine", return_value=fake_engine),
+            patch.object(module.event, "listens_for") as fake_listens_for,
+        ):
+            engine = tool._create_engine()
+
+        assert engine is fake_engine
+        fake_listens_for.assert_not_called()
+
+    def test_read_write_mode_does_not_raise_for_unsupported_dialect(self):
+        module = load_tool_main("natural_language_to_sql_tool")
+        tool = _make_tool(module, "sqlite:///:memory:", read_only=False)
+        fake_engine = _fake_engine("sqlite")
+
+        # Should not raise: the dialect-support check is only enforced when
+        # read_only is True.
+        with patch.object(module, "create_engine", return_value=fake_engine):
+            engine = tool._create_engine()
+
+        assert engine is fake_engine

--- a/src/shared/tools/tests/test_natural_language_to_sql_tool.py
+++ b/src/shared/tools/tests/test_natural_language_to_sql_tool.py
@@ -117,6 +117,115 @@ class TestNaturalLanguageToSQLToolUnsupportedDialect:
         assert "sqlite" in str(exc_info.value)
 
 
+class TestNaturalLanguageToSQLToolModelAndApiKey:
+    def test_model_defaults_to_gpt_4o_mini_when_not_set(self):
+        module = load_tool_main("natural_language_to_sql_tool")
+        module.state = {
+            "variables": {
+                "DB_URI": "postgresql+psycopg2://user:pass@localhost/db",
+                "OPENAI_API_KEY": "sk-test",
+                "READ_ONLY": False,
+            }
+        }
+        tool = module.NaturalLanguageToSQLTool()
+
+        assert tool.model == "gpt-4o-mini"
+
+    def test_model_defaults_to_gpt_4o_mini_and_is_passed_to_chatlitellm(self):
+        module = load_tool_main("natural_language_to_sql_tool")
+        module.state = {
+            "variables": {
+                "DB_URI": "postgresql+psycopg2://user:pass@localhost/db",
+                "OPENAI_API_KEY": "sk-test",
+                "READ_ONLY": False,
+            }
+        }
+        tool = module.NaturalLanguageToSQLTool()
+        fake_engine = _fake_engine("postgresql")
+
+        with (
+            patch.object(module, "create_engine", return_value=fake_engine),
+            patch.object(module, "ChatLiteLLM") as fake_chat_litellm,
+            patch.object(module, "SQLDatabase") as fake_sql_database,
+            patch.object(module, "create_sql_agent") as fake_create_sql_agent,
+        ):
+            fake_sql_database.return_value.dialect = "postgresql"
+            tool._create_agent()
+
+        fake_chat_litellm.assert_called_once_with(
+            model="gpt-4o-mini", temperature=0, api_key="sk-test"
+        )
+
+    def test_non_default_model_is_passed_through_to_chatlitellm(self):
+        module = load_tool_main("natural_language_to_sql_tool")
+        module.state = {
+            "variables": {
+                "DB_URI": "postgresql+psycopg2://user:pass@localhost/db",
+                "MODEL": "anthropic/claude-3-5-sonnet-20241022",
+                "OPENAI_API_KEY": "sk-test",
+                "READ_ONLY": False,
+            }
+        }
+        tool = module.NaturalLanguageToSQLTool()
+        fake_engine = _fake_engine("postgresql")
+
+        with (
+            patch.object(module, "create_engine", return_value=fake_engine),
+            patch.object(module, "ChatLiteLLM") as fake_chat_litellm,
+            patch.object(module, "SQLDatabase") as fake_sql_database,
+            patch.object(module, "create_sql_agent") as fake_create_sql_agent,
+        ):
+            fake_sql_database.return_value.dialect = "postgresql"
+            tool._create_agent()
+
+        fake_chat_litellm.assert_called_once_with(
+            model="anthropic/claude-3-5-sonnet-20241022",
+            temperature=0,
+            api_key="sk-test",
+        )
+
+    def test_api_key_falls_back_to_openai_api_key(self):
+        module = load_tool_main("natural_language_to_sql_tool")
+        module.state = {
+            "variables": {
+                "DB_URI": "postgresql+psycopg2://user:pass@localhost/db",
+                "OPENAI_API_KEY": "sk-legacy",
+                "READ_ONLY": False,
+            }
+        }
+        tool = module.NaturalLanguageToSQLTool()
+
+        assert tool.api_key == "sk-legacy"
+
+    def test_api_key_takes_precedence_over_openai_api_key(self):
+        module = load_tool_main("natural_language_to_sql_tool")
+        module.state = {
+            "variables": {
+                "DB_URI": "postgresql+psycopg2://user:pass@localhost/db",
+                "API_KEY": "sk-new",
+                "OPENAI_API_KEY": "sk-legacy",
+                "READ_ONLY": False,
+            }
+        }
+        tool = module.NaturalLanguageToSQLTool()
+
+        assert tool.api_key == "sk-new"
+
+    def test_missing_both_api_key_variables_raises_runtime_error(self):
+        module = load_tool_main("natural_language_to_sql_tool")
+        module.state = {
+            "variables": {
+                "DB_URI": "postgresql+psycopg2://user:pass@localhost/db",
+                "READ_ONLY": False,
+            }
+        }
+
+        with pytest.raises(RuntimeError) as exc_info:
+            module.NaturalLanguageToSQLTool()
+
+        assert "API_KEY" in str(exc_info.value)
+
+
 class TestNaturalLanguageToSQLToolReadWrite:
     def test_read_write_mode_registers_no_read_only_listener(self):
         module = load_tool_main("natural_language_to_sql_tool")


### PR DESCRIPTION
…l_language_to_sql_tool

The tool previously relied solely on a crud_policy sentence injected into the LLM's prompt to prevent writes -- a request the model could be talked out of, not an actual permission. Now the underlying SQLAlchemy engine registers a connect-event hook that puts the session itself into read-only mode (Postgres: SET SESSION CHARACTERISTICS AS TRANSACTION READ ONLY; MySQL: SET SESSION TRANSACTION READ ONLY) before any agent-generated SQL can run on it, so the database rejects writes regardless of what the model produces. Unsupported dialects fail loudly instead of silently falling back to prompt-only enforcement. The prompt text is kept only as a UX hint.

Adds explicit sqlalchemy dependency and a test file covering the per-dialect listener behavior and the unsupported-dialect failure path.

## Description

<!-- Describe what this PR changes and why. -->

## Checklist

- [ ] I have signed the **Contributor License Agreement (CLA)**. The CLA bot will comment on this PR — comment `I have read the CLA Document and I hereby sign the CLA` to sign. **This PR cannot be merged until the CLA is signed.**
- [ ] My code follows the project's style and conventions.
- [ ] I have tested my changes.
- [ ] I have updated documentation where needed.
