### PR TITLE
fix: add allow list for urls in git tools

### DIFF
--- a/src/tool/custom_tools/mcp_tools/git_tools/.dockerignore
+++ b/src/tool/custom_tools/mcp_tools/git_tools/.dockerignore
@@ -1,2 +1,3 @@
 .venv
 venv
+.env

--- a/src/tool/custom_tools/mcp_tools/git_tools/.env.example
+++ b/src/tool/custom_tools/mcp_tools/git_tools/.env.example
@@ -1,0 +1,21 @@
+# Copy to .env next to docker-compose.yaml:  cp .env.example .env
+#
+# Comma-separated allow-list of URL bases the git tools may talk to.
+# A tool call whose `url` is not under one of these bases is refused BEFORE the
+# caller's token is sent anywhere (SSRF / token-exfiltration guard).
+#
+# Matching rules per entry:
+#   - scheme, host and port must match exactly (port defaults to 443/80)
+#   - a path, if present, is treated as a required prefix
+#   - a leading "*." wildcards subdomains, e.g. https://*.gitlab.example.com
+#
+# GitHub tools always target https://api.github.com - keep it listed to allow them.
+GIT_TOOLS_ALLOWED_URLS=https://gitlab.com,https://github.com,https://api.github.com
+
+# Allow allow-listed hosts that resolve to private / loopback / link-local
+# addresses. Keep false unless you run a self-hosted GitLab on an internal
+# network: true disables the RFC1918 + 169.254.169.254 metadata block.
+GIT_TOOLS_ALLOW_PRIVATE_HOSTS=false
+
+PYTHONUNBUFFERED=1
+FASTMCP_LOG_LEVEL=debug

--- a/src/tool/custom_tools/mcp_tools/git_tools/README.md
+++ b/src/tool/custom_tools/mcp_tools/git_tools/README.md
@@ -1,5 +1,22 @@
 ## Run command
-`docker compose up`
+`cp .env.example .env` (optional - defaults are safe), then `docker compose up`
+
+## Outbound URL allow-list
+
+Tool calls carry a caller-supplied `url` plus a token, so the service refuses to
+send that token anywhere outside an operator-configured allow-list.
+
+Configure in `.env` (see `.env.example`):
+
+| Variable | Default | Meaning |
+| --- | --- | --- |
+| `GIT_TOOLS_ALLOWED_URLS` | `https://gitlab.com,https://github.com,https://api.github.com` | Comma-separated allowed URL bases. Scheme/host/port must match exactly; a path acts as a required prefix; `*.` wildcards subdomains. |
+| `GIT_TOOLS_ALLOW_PRIVATE_HOSTS` | `false` | When `false`, allow-listed hosts that resolve to private / loopback / link-local addresses (e.g. `169.254.169.254`) are still blocked. Set `true` only for a trusted self-hosted GitLab on an internal network. |
+
+A URL outside the list, an embedded credential, a non-http(s) scheme, or an
+empty allow-list all raise `UrlNotAllowedError` before any request is made.
+GitHub tools always target `https://api.github.com`, which must be allow-listed
+for them to work.
 
 ### Available methods:
 - get_open_pull_requests

--- a/src/tool/custom_tools/mcp_tools/git_tools/docker-compose.yaml
+++ b/src/tool/custom_tools/mcp_tools/git_tools/docker-compose.yaml
@@ -7,7 +7,13 @@ services:
 
     ports:
       - "8082:8000"
+    env_file:
+      - path: .env
+        required: false
     environment:
       - PYTHONUNBUFFERED=1
       - FASTMCP_LOG_LEVEL=debug
-
+      # Outbound URL allow-list (see .env.example). Defaults to the public
+      # gitlab.com / github.com endpoints when unset.
+      - GIT_TOOLS_ALLOWED_URLS=${GIT_TOOLS_ALLOWED_URLS:-https://gitlab.com,https://github.com,https://api.github.com}
+      - GIT_TOOLS_ALLOW_PRIVATE_HOSTS=${GIT_TOOLS_ALLOW_PRIVATE_HOSTS:-false}

--- a/src/tool/custom_tools/mcp_tools/git_tools/src/__init__.py
+++ b/src/tool/custom_tools/mcp_tools/git_tools/src/__init__.py
@@ -2,3 +2,4 @@ from .base_client import BaseClient
 from .github_client import GitHubClient
 from .gitlab_client import GitLabClient
 from .client_factory import ClientFactory
+from .url_policy import UrlNotAllowedError, assert_url_allowed

--- a/src/tool/custom_tools/mcp_tools/git_tools/src/client_factory.py
+++ b/src/tool/custom_tools/mcp_tools/git_tools/src/client_factory.py
@@ -3,10 +3,13 @@ from typing import Literal
 from .base_client import BaseClient
 from .github_client import GitHubClient
 from .gitlab_client import GitLabClient
+from .url_policy import assert_url_allowed
+
+GITHUB_API_URL = "https://api.github.com"
+DEFAULT_GITLAB_URL = "https://gitlab.com"
 
 
-class ClientFactoryException(ValueError):
-    ...
+class ClientFactoryException(ValueError): ...
 
 
 class ClientFactory:
@@ -21,9 +24,12 @@ class ClientFactory:
     ) -> BaseClient:
         match client_type:
             case "github":
+                # PyGithub targets api.github.com; still gate it so an operator
+                # allow-list that excludes GitHub blocks the token from leaving.
+                assert_url_allowed(GITHUB_API_URL)
                 return GitHubClient(token=token, owner=owner, repo_name=repo_name)
             case "gitlab":
-                gitlab_url = url or "https://gitlab.com"
+                gitlab_url = assert_url_allowed(url or DEFAULT_GITLAB_URL)
                 return GitLabClient(
                     token=token, owner=owner, repo_name=repo_name, url=gitlab_url
                 )

--- a/src/tool/custom_tools/mcp_tools/git_tools/src/url_policy.py
+++ b/src/tool/custom_tools/mcp_tools/git_tools/src/url_policy.py
@@ -1,0 +1,145 @@
+"""Host allow-list / SSRF guard for outbound Git-provider calls.
+
+Every URL a tool call wants to send a caller token to must pass
+:func:`assert_url_allowed` first. Two independent checks are applied:
+
+1. The URL base must appear in the operator-configured allow-list
+   (``GIT_TOOLS_ALLOWED_URLS`` in the service ``.env``).
+2. The resolved host must not be a private, loopback, link-local or otherwise
+   internal address (blocks ``169.254.169.254`` and friends), unless the
+   operator explicitly opts in via ``GIT_TOOLS_ALLOW_PRIVATE_HOSTS``.
+"""
+
+import ipaddress
+import os
+import socket
+from dataclasses import dataclass
+from typing import Iterable, Tuple
+from urllib.parse import urlsplit
+
+ALLOWED_URLS_ENV = "GIT_TOOLS_ALLOWED_URLS"
+ALLOW_PRIVATE_HOSTS_ENV = "GIT_TOOLS_ALLOW_PRIVATE_HOSTS"
+
+DEFAULT_ALLOWED_URLS = "https://gitlab.com,https://github.com,https://api.github.com"
+
+DEFAULT_PORTS = {"http": 80, "https": 443}
+
+
+class UrlNotAllowedError(ValueError):
+    """Raised when a URL is outside the configured allow-list or resolves internally."""
+
+
+@dataclass(frozen=True)
+class AllowedUrl:
+    scheme: str
+    host: str
+    port: int
+    path_prefix: str
+
+    @classmethod
+    def parse(cls, raw: str) -> "AllowedUrl":
+        parts = urlsplit(raw.strip())
+        if parts.scheme not in DEFAULT_PORTS:
+            raise UrlNotAllowedError(
+                f"Allow-list entry {raw!r} must use http or https scheme"
+            )
+        if not parts.hostname:
+            raise UrlNotAllowedError(f"Allow-list entry {raw!r} has no host")
+        return cls(
+            scheme=parts.scheme,
+            host=parts.hostname.lower().rstrip("."),
+            port=parts.port or DEFAULT_PORTS[parts.scheme],
+            path_prefix=parts.path.rstrip("/"),
+        )
+
+    def matches(self, scheme: str, host: str, port: int, path: str) -> bool:
+        if scheme != self.scheme or port != self.port:
+            return False
+        if not self._host_matches(host):
+            return False
+        if not self.path_prefix:
+            return True
+        return path == self.path_prefix or path.startswith(self.path_prefix + "/")
+
+    def _host_matches(self, host: str) -> bool:
+        if self.host.startswith("*."):
+            return host == self.host[2:] or host.endswith(self.host[1:])
+        return host == self.host
+
+
+def _env_flag(name: str, default: bool = False) -> bool:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def load_allowlist() -> Tuple[AllowedUrl, ...]:
+    raw = os.getenv(ALLOWED_URLS_ENV)
+    if raw is None:
+        raw = DEFAULT_ALLOWED_URLS
+    entries = tuple(AllowedUrl.parse(item) for item in raw.split(",") if item.strip())
+    if not entries:
+        raise UrlNotAllowedError(
+            f"{ALLOWED_URLS_ENV} is empty - no Git host is allowed, refusing to send token"
+        )
+    return entries
+
+
+def _resolved_addresses(host: str, port: int) -> Iterable[ipaddress._BaseAddress]:
+    try:
+        return {
+            ipaddress.ip_address(info[4][0])
+            for info in socket.getaddrinfo(host, port, proto=socket.IPPROTO_TCP)
+        }
+    except socket.gaierror as exc:
+        raise UrlNotAllowedError(f"Cannot resolve host {host!r}: {exc}") from exc
+
+
+def _assert_public_host(host: str, port: int) -> None:
+    for address in _resolved_addresses(host, port):
+        if (
+            address.is_private
+            or address.is_loopback
+            or address.is_link_local
+            or address.is_reserved
+            or address.is_multicast
+            or address.is_unspecified
+        ):
+            raise UrlNotAllowedError(
+                f"Host {host!r} resolves to internal address {address} - blocked. "
+                f"Set {ALLOW_PRIVATE_HOSTS_ENV}=true only for trusted self-hosted instances."
+            )
+
+
+def assert_url_allowed(url: str) -> str:
+    """Return the normalized URL, or raise :class:`UrlNotAllowedError`."""
+    if not url or not url.strip():
+        raise UrlNotAllowedError("Empty URL is not allowed")
+
+    parts = urlsplit(url.strip())
+    if parts.scheme not in DEFAULT_PORTS:
+        raise UrlNotAllowedError(f"Unsupported scheme in {url!r}: only http/https")
+    if not parts.hostname:
+        raise UrlNotAllowedError(f"URL {url!r} has no host")
+    if parts.username or parts.password:
+        raise UrlNotAllowedError("Credentials embedded in the URL are not allowed")
+
+    host = parts.hostname.lower().rstrip(".")
+    port = parts.port or DEFAULT_PORTS[parts.scheme]
+    path = parts.path.rstrip("/")
+
+    allowlist = load_allowlist()
+    if not any(entry.matches(parts.scheme, host, port, path) for entry in allowlist):
+        allowed = ", ".join(
+            f"{e.scheme}://{e.host}:{e.port}{e.path_prefix}" for e in allowlist
+        )
+        raise UrlNotAllowedError(
+            f"URL {url!r} is not in {ALLOWED_URLS_ENV}. Allowed bases: {allowed}"
+        )
+
+    if not _env_flag(ALLOW_PRIVATE_HOSTS_ENV):
+        _assert_public_host(host, port)
+
+    netloc = host if port == DEFAULT_PORTS[parts.scheme] else f"{host}:{port}"
+    return f"{parts.scheme}://{netloc}{path}"


### PR DESCRIPTION
## Description

Set allow list for URLs that can be used in git tools

## Checklist

- [x] I have signed the **Contributor License Agreement (CLA)**. The CLA bot will comment on this PR — comment `I have read the CLA Document and I hereby sign the CLA` to sign. **This PR cannot be merged until the CLA is signed.**
- [x] My code follows the project's style and conventions.
- [x] I have tested my changes.
- [x] I have updated documentation where needed.
