### PR TITLE
chore(EST-3868-BE): switch yaml.FullLoader to yaml.safe_load

### DIFF
--- a/src/crew/utils/envpy.py
+++ b/src/crew/utils/envpy.py
@@ -7,7 +7,7 @@ def load_env_from_yaml_config(yaml_config_path):
     loaded = False
     try:
         with open(Path(yaml_config_path).resolve()) as f:
-            cfg: dict = yaml.load(f, Loader=yaml.FullLoader)
+            cfg: dict = yaml.safe_load(f)
         for k, v in cfg.items():
             os.environ[k] = v
         loaded = True

--- a/src/manager/helpers/yaml_parser.py
+++ b/src/manager/helpers/yaml_parser.py
@@ -7,7 +7,7 @@ def load_env_from_yaml_config(yaml_config_path):
     loaded = False
     try:
         with open(Path(yaml_config_path).resolve()) as f:
-            cfg: dict = yaml.load(f, Loader=yaml.FullLoader)
+            cfg: dict = yaml.safe_load(f)
         for k, v in cfg["constants"].items():
             os.environ[k] = v
         loaded = True

--- a/src/tool/utils.py
+++ b/src/tool/utils.py
@@ -94,7 +94,7 @@ def load_env_from_yaml_config(yaml_config_path):
     loaded = False
     try:
         with open(Path(yaml_config_path).resolve()) as f:
-            cfg: dict = yaml.load(f, Loader=yaml.FullLoader)
+            cfg: dict = yaml.safe_load(f)
         for k, v in cfg.items():
             os.environ[k] = v
             logger.info(f"loaded {k}")


### PR DESCRIPTION
switch yaml.FullLoader to yaml.safe_load

FullLoader can resolve YAML tags into arbitrary already-imported Python objects (e.g. python/name:os.system), which is unnecessary risk for files that only ever carry plain scalar env values. safe_load rejects those tags outright while parsing identical legitimate configs unchanged.

Security review finding #45 (MEDIUM).
