### PR TITLE
fix(EST-0000): resolve FlowAssistant API key off the async path

### DIFF
--- a/src/django_app/tables/services/flow_assistant/service.py
+++ b/src/django_app/tables/services/flow_assistant/service.py
@@ -22,7 +22,11 @@ from django.utils import timezone
 
 from utils.logger import logger
 
-from tables.exceptions import LLMConfigMissingError, LLMConfigInvalidError, ToolExecutionError
+from tables.exceptions import (
+    LLMConfigMissingError,
+    LLMConfigInvalidError,
+    ToolExecutionError,
+)
 from tables.models.flow_assistant_models import (
     FlowAssistant,
     FlowAssistantConversation,
@@ -38,6 +42,7 @@ from tables.services.llm_clients import (
     UnsupportedLLMProviderError,
     get_llm_client,
 )
+from tables.services.secrets import secret_resolver
 from . import partial_json as _partial_json
 from .tools import _NODE_TABLES, _TOOL_CALLABLES, TOOL_SPECS
 from .constants import _MAX_TOOL_ITERATIONS, _REASONING_EMPTY_HINT
@@ -208,7 +213,9 @@ class FlowAssistantService:
         last_message_at in a single atomic block. Returns the created row.
         """
         with transaction.atomic():
-            next_idx_result = conversation.message_rows.aggregate(m=Max("message_index"))
+            next_idx_result = conversation.message_rows.aggregate(
+                m=Max("message_index")
+            )
             next_idx = next_idx_result["m"]
             next_idx = 0 if next_idx is None else next_idx + 1
             row = FlowAssistantMessage.objects.create(
@@ -249,10 +256,18 @@ class FlowAssistantService:
                 f"FlowAssistant for graph {flow_assistant.graph_id} has no llm_config set."
             )
 
+        # sync_to_async: stream_reply is an async generator, so the ORM lookup cannot run inline.
+        api_key = await sync_to_async(secret_resolver.resolve)(
+            secret_id=flow_assistant.llm_config.api_key_secret_id,
+            org_id=flow_assistant.llm_config.org_id,
+            context="FlowAssistant.llm_config.api_key",
+        )
+
         try:
             client = get_llm_client(
                 flow_assistant.llm_config,
                 output_schema=FLOW_ASSISTANT_OUTPUT_SCHEMA,
+                api_key=api_key,
             )
         except UnsupportedLLMProviderError as exc:
             raise LLMConfigInvalidError(str(exc)) from exc

--- a/src/django_app/tables/services/llm_clients/__init__.py
+++ b/src/django_app/tables/services/llm_clients/__init__.py
@@ -31,6 +31,8 @@ __all__ = [
 def get_llm_client(
     llm_config,
     output_schema: dict | None = None,
+    *,
+    api_key: str | None,
 ) -> BaseLLMClient:
     """Return a LiteLLMClient for the given LLMConfig.
 
@@ -38,10 +40,17 @@ def get_llm_client(
     request structured JSON output (e.g. ``response_format: json_schema``)
     without mutating the persisted ``LLMConfig`` row.
 
+    ``api_key`` must be resolved by the caller (via
+    ``tables.services.secrets.secret_resolver``) before calling this function;
+    it has no default so omitting it fails loudly instead of silently sending
+    an unauthenticated request. ``None`` is a legitimate explicit value for
+    providers that need no credential. Async callers must wrap the resolution
+    in ``sync_to_async`` — LiteLLMClient itself must not touch the ORM.
+
     The model string is derived inside LiteLLMClient from
     ``llm_config.model.llm_provider.name`` + ``llm_config.model.name``, so any
     provider supported by LiteLLM works without any code change here.
 
     Raises ``UnsupportedLLMProviderError`` when the model or provider is missing.
     """
-    return LiteLLMClient(llm_config, output_schema=output_schema)
+    return LiteLLMClient(llm_config, api_key=api_key, output_schema=output_schema)

--- a/src/django_app/tables/services/llm_clients/litellm_client.py
+++ b/src/django_app/tables/services/llm_clients/litellm_client.py
@@ -6,7 +6,6 @@ from typing import AsyncIterator
 
 import litellm
 
-from tables.services.secrets import secret_resolver
 from utils.logger import logger
 
 from .base import (
@@ -42,9 +41,17 @@ class LiteLLMClient(BaseLLMClient):
     behavior because they also used LiteLLM internally.  Tracked separately.
     """
 
-    def __init__(self, llm_config, output_schema: dict | None = None) -> None:
+    def __init__(
+        self,
+        llm_config,
+        *,
+        api_key: str | None,
+        output_schema: dict | None = None,
+    ) -> None:
         super().__init__(output_schema=output_schema)
         self._llm_config = llm_config
+        # Resolved by the caller; this class must not touch the ORM (see get_llm_client).
+        self._api_key = api_key
         # Validate and cache the model string eagerly so callers receive
         # UnsupportedLLMProviderError at construction time (fail-fast), not
         # lazily during the first stream_completion call.
@@ -109,13 +116,8 @@ class LiteLLMClient(BaseLLMClient):
             "stream": True,
         }
 
-        api_key = secret_resolver.resolve(
-            secret_id=cfg.api_key_secret_id,
-            org_id=cfg.org_id,
-            context="LiteLLMClient.api_key",
-        )
-        if api_key:
-            kwargs["api_key"] = api_key
+        if self._api_key:
+            kwargs["api_key"] = self._api_key
         if model and model.base_url:
             kwargs["base_url"] = model.base_url
         if model and getattr(model, "api_version", None):

--- a/src/django_app/tables/views/flow_assistant_views.py
+++ b/src/django_app/tables/views/flow_assistant_views.py
@@ -42,6 +42,7 @@ from tables.services.rbac.organization_resolution import resolve_organization_us
 from tables.services.rbac.permission_assert import assert_org_permission
 from tables.services.rbac.permissions import IsSuperadmin
 from tables.services.rbac.ticket_service import sse_ticket_service
+from tables.services.secrets import SecretResolutionError
 from tables.utils.mixins import SSEMixin
 from utils.logger import logger
 
@@ -388,6 +389,14 @@ class FlowAssistantStreamView(SSEMixin):
         except LLMConfigInvalidError as exc:
             logger.warning(
                 "FlowAssistant stream error (LLMConfigInvalidError): {}", exc
+            )
+            yield {
+                "event": "error",
+                "data": {"type": "error", "detail": str(exc)},
+            }
+        except SecretResolutionError as exc:
+            logger.warning(
+                "FlowAssistant stream error (SecretResolutionError): {}", exc
             )
             yield {
                 "event": "error",

--- a/src/django_app/tests/api_tests/test_flow_assistant.py
+++ b/src/django_app/tests/api_tests/test_flow_assistant.py
@@ -580,6 +580,87 @@ def test_title_not_overwritten_on_second_message(
 
 @pytest.mark.asyncio
 @pytest.mark.django_db(transaction=True)
+async def test_stream_reply_resolves_real_secret_for_real_litellm_client(
+    gpt4_model, user_a, org_a, default_role, db
+):
+    """Regression test for a SynchronousOnlyOperation bug in LiteLLMClient.
+
+    Every other streaming test in this module patches
+    `tables.services.flow_assistant.service.get_llm_client` with a MagicMock,
+    so the real `LiteLLMClient._build_kwargs` never runs. That hid a bug where
+    `_build_kwargs` resolved the LLMConfig's `api_key_secret` with a
+    synchronous `Secret.objects.filter(...).first()` call from inside this
+    async generator (`stream_reply`) — raising `SynchronousOnlyOperation`
+    under ASGI for the first turn of any conversation whose LLMConfig has a
+    real secret attached.
+
+    This test drives the real `get_llm_client` / `LiteLLMClient` path with a
+    genuine `Secret` row and asserts the resolved plaintext reaches
+    `litellm.acompletion`'s kwargs. Only the network call itself is stubbed.
+    Running under `@pytest.mark.asyncio` is required: a synchronous test has
+    no running event loop, so the async-unsafe ORM guard never trips and a
+    reintroduced bug here would pass silently.
+    """
+    from asgiref.sync import sync_to_async
+
+    from tables.services.secrets import secret_service
+
+    org_user = await sync_to_async(OrganizationUser.objects.create)(
+        user=user_a, org=org_a, role=default_role
+    )
+    # Explicit org=org_a (rather than the module's org-less `graph` fixture):
+    # `tables_graph.org_id` is NOT NULL at the DB level (migration
+    # 0186_core_org_not_null), and this test's own LLMConfig/Secret need a
+    # concrete org to be scoped to regardless.
+    graph_with_org = await sync_to_async(Graph.objects.create)(
+        name="Test Flow", description="A test flow.", org=org_a
+    )
+    secret = await sync_to_async(secret_service.create)(
+        text="sk-flow-assistant-real-secret", org=org_a, name="fa-litellm-key"
+    )
+    llm_config_with_secret = await sync_to_async(LLMConfig.objects.create)(
+        custom_name="test-gpt4o-with-secret",
+        model=gpt4_model,
+        org=org_a,
+        api_key_secret=secret,
+        temperature=0.5,
+    )
+    assistant = await sync_to_async(FlowAssistant.objects.create)(
+        graph=graph_with_org, llm_config=llm_config_with_secret
+    )
+    user_message = "what does this flow do?"
+    conversation = await sync_to_async(_make_conversation_with_messages)(
+        assistant,
+        org_user,
+        [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": user_message},
+        ],
+    )
+
+    captured_kwargs: dict = {}
+
+    async def fake_acompletion(**kwargs):
+        captured_kwargs.update(kwargs)
+
+        async def _empty_stream():
+            return
+            yield  # pragma: no cover - makes this an async generator
+
+        return _empty_stream()
+
+    service = FlowAssistantService()
+    events = []
+    with patch("litellm.acompletion", side_effect=fake_acompletion):
+        async for event in service.stream_reply(conversation, user_message):
+            events.append(event)
+
+    assert captured_kwargs.get("api_key") == "sk-flow-assistant-real-secret"
+    assert events[-1].type == "done"
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
 async def test_stream_yields_tokens_and_done(
     graph, llm_config, user_a, org_a, default_role, db
 ):

--- a/src/django_app/tests/services_tests/test_secret_service_call_sites.py
+++ b/src/django_app/tests/services_tests/test_secret_service_call_sites.py
@@ -2,8 +2,9 @@
 
 The FK-wiring change renamed the raw credential columns out from under several
 services. Every one of them is now wired: quickstart and Telegram directly, the
-converter via id-carrying payload fields, and litellm_client via
-SecretResolver.resolve. Nothing here is deferred any more.
+converter via id-carrying payload fields, and the FlowAssistant streaming path
+via SecretResolver.resolve called by the caller of LiteLLMClient (never by
+LiteLLMClient itself — see litellm_client.py). Nothing here is deferred any more.
 """
 
 import pytest
@@ -194,10 +195,15 @@ class TestPayloadAndInProcessConsumers:
         assert data.config.api_key is None
         assert data.config.api_key_secret_id is None
 
-    def test_litellm_client_builds_kwargs(self, org):
+    def test_secret_resolver_resolves_litellm_config_api_key(self, org):
+        """The resolver turns a LiteLLM config's api_key_secret FK into plaintext.
+
+        LiteLLMClient no longer calls the resolver itself (it is constructed on
+        an async request path — see litellm_client.py docstring); the caller
+        resolves this value. This test covers that resolution in isolation.
+        """
         from tables.models import LLMModel
-        from tables.services.llm_clients.litellm_client import LiteLLMClient
-        from tables.services.secrets import secret_service
+        from tables.services.secrets import secret_resolver, secret_service
 
         provider, _ = Provider.objects.get_or_create(name="openai")
         model = LLMModel.objects.create(name="gpt-4o-lite-test", llm_provider=provider)
@@ -208,11 +214,29 @@ class TestPayloadAndInProcessConsumers:
             custom_name="lite-test", model=model, org=org, api_key_secret=secret
         )
 
-        kwargs = LiteLLMClient(llm_config=config)._build_kwargs(messages=[], tools=[])
+        api_key = secret_resolver.resolve(
+            secret_id=config.api_key_secret_id,
+            org_id=config.org_id,
+            context="LiteLLMClient.api_key",
+        )
+
+        assert api_key == "sk-litellm-resolved"
+
+    def test_litellm_client_build_kwargs_includes_supplied_api_key(self, org):
+        from tables.models import LLMModel
+        from tables.services.llm_clients.litellm_client import LiteLLMClient
+
+        provider, _ = Provider.objects.get_or_create(name="openai")
+        model = LLMModel.objects.create(name="gpt-4o-lite-test", llm_provider=provider)
+        config = LLMConfig.objects.create(custom_name="lite-test", model=model, org=org)
+
+        kwargs = LiteLLMClient(
+            llm_config=config, api_key="sk-litellm-resolved"
+        )._build_kwargs(messages=[], tools=[])
 
         assert kwargs["api_key"] == "sk-litellm-resolved"
 
-    def test_litellm_client_omits_api_key_when_no_secret_attached(self, org):
+    def test_litellm_client_omits_api_key_when_none(self, org):
         from tables.models import LLMModel
         from tables.services.llm_clients.litellm_client import LiteLLMClient
 
@@ -222,6 +246,8 @@ class TestPayloadAndInProcessConsumers:
             custom_name="lite-no-key", model=model, org=org
         )
 
-        kwargs = LiteLLMClient(llm_config=config)._build_kwargs(messages=[], tools=[])
+        kwargs = LiteLLMClient(llm_config=config, api_key=None)._build_kwargs(
+            messages=[], tools=[]
+        )
 
         assert "api_key" not in kwargs


### PR DESCRIPTION
LiteLLMClient._build_kwargs resolved the LLMConfig's api_key_secret with a synchronous Secret.objects lookup, and it did so from inside FlowAssistantService.stream_reply — an async generator driven by the SSE view under ASGI (gunicorn + UvicornWorker). Django 5.1 guards the DB cursor with @async_unsafe, so that query raised SynchronousOnlyOperation and killed the stream on the first turn of any conversation whose LLMConfig had a secret attached. It only appeared to work when no secret was set, because SecretResolver.resolve returns early on secret_id=None.

Introduced by c43e66d49, which replaced a plain `cfg.api_key` attribute read with a resolver call — turning a free attribute access into a DB round-trip without moving it off the async path.

The caller now resolves the credential via sync_to_async and passes the plaintext in, so LiteLLMClient no longer touches the ORM at all — correct layering for a transport client, and it keeps the query out of the stream. api_key is keyword-only with no default: None stays a legitimate explicit value for providers needing no credential, but an omission at a call site fails loudly at construction instead of silently sending an unauthenticated request. The plaintext's lifetime is unchanged — it lives only on the per-request client instance, exactly as kwargs["api_key"] already did.

The stream view gains an explicit SecretResolutionError branch so an unreadable credential (rotated SECRET_KEY, missing row) reports itself instead of falling through to the catch-all "Unexpected error."

Adds the regression test that was missing. Every other streaming test in test_flow_assistant.py patches get_llm_client with a MagicMock, so _build_kwargs never ran; the one test that did call it was synchronous, so no event loop existed and the async-unsafe guard never tripped. The new test is @pytest.mark.asyncio, drives the real client with a real Secret row, and stubs only litellm.acompletion. Verified to fail against the pre-fix code.

Note: the two reformatted hunks in service.py are pre-existing ruff-format debt on main, not intentional changes.

I have read the CLA Document and I hereby sign the CLA
