### PR TITLE
fix(EST-2752-FE): fix stale waypoint causing zigzag/loop connections

### DIFF
--- a/frontend/src/app/visual-programming/core/helpers/helpers.spec.ts
+++ b/frontend/src/app/visual-programming/core/helpers/helpers.spec.ts
@@ -85,4 +85,40 @@ describe('isBackwardConnection', () => {
 
         expect(isBackwardConnection(conn, [source])).toBe(false);
     });
+
+    it('stays true for a horizontally-backward connection regardless of the vertical gap between nodes', () => {
+        const source = node('source', 100, 300, 330, 60, 'source_out-right', 'right');
+        const conn = connection('source', 'source_out-right', 'target', 'target_in-left');
+
+        for (const dy of [5, 25, 40, 60, 120, 200]) {
+            const target = node('target', 100, 300 + dy, 330, 60, 'target_in-left', 'left');
+
+            expect(isBackwardConnection(conn, [source, target])).toBe(true);
+        }
+    });
+
+    it('stays false for a vertically-forward connection regardless of the horizontal gap between nodes', () => {
+        const source = node('source', 100, 0, 100, 60, 'source_out-bottom', 'bottom');
+        const conn = connection('source', 'source_out-bottom', 'target', 'target_in-top');
+
+        for (const dx of [5, 25, 40, 60, 120, 200]) {
+            const target = node('target', 100 + dx, 200, 100, 60, 'target_in-top', 'top');
+
+            expect(isBackwardConnection(conn, [source, target])).toBe(false);
+        }
+    });
+
+    it('does not throw for mixed port orientations (falls back to layout dominance)', () => {
+        const rightToTop = node('source', 0, 0, 100, 60, 'source_out-right', 'right');
+        const topTarget = node('target', 300, 0, 100, 60, 'target_in-top', 'top');
+        const c1 = connection('source', 'source_out-right', 'target', 'target_in-top');
+
+        expect(() => isBackwardConnection(c1, [rightToTop, topTarget])).not.toThrow();
+
+        const bottomSource = node('source', 0, 0, 100, 60, 'source_out-bottom', 'bottom');
+        const leftTarget = node('target', 0, 300, 100, 60, 'target_in-left', 'left');
+        const c2 = connection('source', 'source_out-bottom', 'target', 'target_in-left');
+
+        expect(() => isBackwardConnection(c2, [bottomSource, leftTarget])).not.toThrow();
+    });
 });

--- a/frontend/src/app/visual-programming/core/helpers/helpers.spec.ts
+++ b/frontend/src/app/visual-programming/core/helpers/helpers.spec.ts
@@ -1,0 +1,88 @@
+import { ConnectionModel } from '../models/connection.model';
+import { BaseNodeModel } from '../models/node.model';
+import { isBackwardConnection } from './helpers';
+
+function node(
+    id: string,
+    x: number,
+    y: number,
+    width: number,
+    height: number,
+    portId: string,
+    portPosition: string
+): BaseNodeModel {
+    return {
+        id,
+        position: { x, y },
+        size: { width, height },
+        ports: [{ id: portId, position: portPosition }],
+    } as unknown as BaseNodeModel;
+}
+
+function connection(
+    sourceNodeId: string,
+    sourcePortId: string,
+    targetNodeId: string,
+    targetPortId: string
+): ConnectionModel {
+    return {
+        id: 'conn-1',
+        sourceNodeId,
+        targetNodeId,
+        sourcePortId,
+        targetPortId,
+    } as unknown as ConnectionModel;
+}
+
+describe('isBackwardConnection', () => {
+    it('is false for a horizontal forward connection (source left of target)', () => {
+        const source = node('source', 0, 0, 100, 60, 'source_out-right', 'right');
+        const target = node('target', 300, 0, 100, 60, 'target_in-left', 'left');
+        const conn = connection('source', 'source_out-right', 'target', 'target_in-left');
+
+        expect(isBackwardConnection(conn, [source, target])).toBe(false);
+    });
+
+    it('is true for a horizontal backward connection (source exit past target entry)', () => {
+        const source = node('source', 300, 0, 100, 60, 'source_out-right', 'right');
+        const target = node('target', 0, 0, 100, 60, 'target_in-left', 'left');
+        const conn = connection('source', 'source_out-right', 'target', 'target_in-left');
+
+        expect(isBackwardConnection(conn, [source, target])).toBe(true);
+    });
+
+    it('is false for a vertical forward connection (source above target)', () => {
+        const source = node('source', 0, 0, 100, 100, 'source_out-bottom', 'bottom');
+        const target = node('target', 0, 300, 100, 100, 'target_in-top', 'top');
+        const conn = connection('source', 'source_out-bottom', 'target', 'target_in-top');
+
+        expect(isBackwardConnection(conn, [source, target])).toBe(false);
+    });
+
+    it('is true for a vertical backward connection (source exit past target entry)', () => {
+        const source = node('source', 0, 300, 100, 100, 'source_out-bottom', 'bottom');
+        const target = node('target', 0, 0, 100, 100, 'target_in-top', 'top');
+        const conn = connection('source', 'source_out-bottom', 'target', 'target_in-top');
+
+        expect(isBackwardConnection(conn, [source, target])).toBe(true);
+    });
+
+    it('flips from backward to forward when the target moves past the source exit edge', () => {
+        const source = node('source', 300, 0, 100, 60, 'source_out-right', 'right');
+        const backwardTarget = node('target', 0, 0, 100, 60, 'target_in-left', 'left');
+        const conn = connection('source', 'source_out-right', 'target', 'target_in-left');
+
+        expect(isBackwardConnection(conn, [source, backwardTarget])).toBe(true);
+
+        const forwardTarget = node('target', 500, 0, 100, 60, 'target_in-left', 'left');
+
+        expect(isBackwardConnection(conn, [source, forwardTarget])).toBe(false);
+    });
+
+    it('is false when either node is missing', () => {
+        const source = node('source', 0, 0, 100, 60, 'source_out-right', 'right');
+        const conn = connection('source', 'source_out-right', 'missing-target', 'target_in-left');
+
+        expect(isBackwardConnection(conn, [source])).toBe(false);
+    });
+});

--- a/frontend/src/app/visual-programming/core/helpers/helpers.ts
+++ b/frontend/src/app/visual-programming/core/helpers/helpers.ts
@@ -417,6 +417,32 @@ function getConnectionLayout(
     return 'mixed';
 }
 
+function isHorizontalBackward(
+    source: BaseNodeModel,
+    target: BaseNodeModel,
+    sourcePort?: ViewPort,
+    targetPort?: ViewPort
+): boolean {
+    const sourceExitX = sourcePort?.position === 'left' ? source.position.x : source.position.x + source.size.width;
+
+    const targetEntryX = targetPort?.position === 'right' ? target.position.x + target.size.width : target.position.x;
+
+    return sourceExitX > targetEntryX;
+}
+
+function isVerticalBackward(
+    source: BaseNodeModel,
+    target: BaseNodeModel,
+    sourcePort?: ViewPort,
+    targetPort?: ViewPort
+): boolean {
+    const sourceExitY = sourcePort?.position === 'top' ? source.position.y : source.position.y + source.size.height;
+
+    const targetEntryY = targetPort?.position === 'bottom' ? target.position.y + target.size.height : target.position.y;
+
+    return sourceExitY > targetEntryY;
+}
+
 export function isBackwardConnection(connection: ConnectionModel, nodes: BaseNodeModel[]): boolean {
     const source = nodes.find((n) => n.id === connection.sourceNodeId);
     const target = nodes.find((n) => n.id === connection.targetNodeId);
@@ -425,46 +451,25 @@ export function isBackwardConnection(connection: ConnectionModel, nodes: BaseNod
     const sourcePort = source.ports?.find((p) => p.id === connection.sourcePortId);
     const targetPort = target.ports?.find((p) => p.id === connection.targetPortId);
 
-    const layout = getConnectionLayout(source, target, sourcePort, targetPort);
-
-    if (layout === 'horizontal') {
-        const sourceExitX = sourcePort?.position === 'left' ? source.position.x : source.position.x + source.size.width;
-
-        const targetEntryX =
-            targetPort?.position === 'right' ? target.position.x + target.size.width : target.position.x;
-
-        return sourceExitX > targetEntryX;
-    }
-
-    if (layout === 'vertical') {
-        const sourceExitY = sourcePort?.position === 'top' ? source.position.y : source.position.y + source.size.height;
-
-        const targetEntryY =
-            targetPort?.position === 'bottom' ? target.position.y + target.size.height : target.position.y;
-
-        return sourceExitY > targetEntryY;
-    }
-
     const bothHorizontalPorts = isHorizontalPort(sourcePort?.position) && isHorizontalPort(targetPort?.position);
-
     const bothVerticalPorts = isVerticalPort(sourcePort?.position) && isVerticalPort(targetPort?.position);
 
     if (bothHorizontalPorts) {
-        const sourceExitX = sourcePort?.position === 'left' ? source.position.x : source.position.x + source.size.width;
-
-        const targetEntryX =
-            targetPort?.position === 'right' ? target.position.x + target.size.width : target.position.x;
-
-        return sourceExitX > targetEntryX;
+        return isHorizontalBackward(source, target, sourcePort, targetPort);
     }
 
     if (bothVerticalPorts) {
-        const sourceExitY = sourcePort?.position === 'top' ? source.position.y : source.position.y + source.size.height;
+        return isVerticalBackward(source, target, sourcePort, targetPort);
+    }
 
-        const targetEntryY =
-            targetPort?.position === 'bottom' ? target.position.y + target.size.height : target.position.y;
+    const layout = getConnectionLayout(source, target, sourcePort, targetPort);
 
-        return sourceExitY > targetEntryY;
+    if (layout === 'horizontal') {
+        return isHorizontalBackward(source, target, sourcePort, targetPort);
+    }
+
+    if (layout === 'vertical') {
+        return isVerticalBackward(source, target, sourcePort, targetPort);
     }
 
     return false;

--- a/frontend/src/app/visual-programming/core/helpers/node-placement.utils.ts
+++ b/frontend/src/app/visual-programming/core/helpers/node-placement.utils.ts
@@ -1,8 +1,8 @@
 import { IPoint } from '@foblex/2d';
 
 import { NodeType } from '../enums/node-type';
-import { DecisionTableNodeModel, NodeModel } from '../models/node.model';
-import { getDecisionTableVisualHeight } from './node-size.util';
+import { ClassificationDecisionTableNodeModel, DecisionTableNodeModel, NodeModel } from '../models/node.model';
+import { getClassificationDecisionTableVisualHeight, getDecisionTableVisualHeight } from './node-size.util';
 
 export interface CollisionBounds {
     width: number;
@@ -36,6 +36,16 @@ export function getCollisionBounds(node: Pick<NodeModel, 'type' | 'size' | 'data
             return {
                 width: node.size.width + 40,
                 height: getDecisionTableVisualHeight(conditionGroups) + 68,
+                offsetX: -20,
+                offsetY: -15,
+            };
+        }
+
+        case NodeType.CLASSIFICATION_TABLE: {
+            const conditionGroups = (node as ClassificationDecisionTableNodeModel).data.table?.condition_groups ?? [];
+            return {
+                width: node.size.width + 40,
+                height: getClassificationDecisionTableVisualHeight(conditionGroups) + 30,
                 offsetX: -20,
                 offsetY: -15,
             };

--- a/frontend/src/app/visual-programming/core/helpers/node-size.util.spec.ts
+++ b/frontend/src/app/visual-programming/core/helpers/node-size.util.spec.ts
@@ -1,0 +1,29 @@
+import { getClassificationDecisionTableVisualHeight } from './node-size.util';
+
+describe('getClassificationDecisionTableVisualHeight', () => {
+    it('reserves one placeholder row when there are no condition groups', () => {
+        expect(getClassificationDecisionTableVisualHeight([])).toBe(60 + 46 * 3);
+    });
+
+    it('counts only groups that would actually render a row (valid, dock_visible, has a route_code)', () => {
+        const groups = [
+            { valid: true, dock_visible: true, route_code: 'A' },
+            { valid: false, dock_visible: true, route_code: 'B' },
+            { valid: true, dock_visible: false, route_code: 'C' },
+            { valid: true, dock_visible: true, route_code: undefined },
+            { valid: true, dock_visible: true, route_code: 'D' },
+        ];
+
+        expect(getClassificationDecisionTableVisualHeight(groups)).toBe(60 + 46 * 4);
+    });
+
+    it('grows linearly as more groups are added', () => {
+        const groups = Array.from({ length: 6 }, (_, i) => ({
+            valid: true,
+            dock_visible: true,
+            route_code: `route-${i}`,
+        }));
+
+        expect(getClassificationDecisionTableVisualHeight(groups)).toBe(60 + 46 * 8);
+    });
+});

--- a/frontend/src/app/visual-programming/core/helpers/node-size.util.ts
+++ b/frontend/src/app/visual-programming/core/helpers/node-size.util.ts
@@ -12,6 +12,21 @@ export function getDecisionTableVisualHeight(conditionGroups: { valid?: boolean 
     return Math.max(HEADER_HEIGHT + ROW_HEIGHT * totalRows, MIN_TABLE_HEIGHT);
 }
 
+const CDT_HEADER_HEIGHT = 60;
+const CDT_ROW_HEIGHT = 46;
+const CDT_BASE_ROWS = 2;
+
+export function getClassificationDecisionTableVisualHeight(
+    conditionGroups: { valid?: boolean; dock_visible?: boolean; route_code?: string }[]
+): number {
+    const renderedGroupRows = conditionGroups.filter(
+        (g) => g.valid !== false && g.dock_visible && !!g.route_code
+    ).length;
+    const groupRows = Math.max(renderedGroupRows, 1);
+    const totalRows = groupRows + CDT_BASE_ROWS;
+    return CDT_HEADER_HEIGHT + CDT_ROW_HEIGHT * totalRows;
+}
+
 export function getDefaultNodeSize(type: NodeType, data?: unknown): { width: number; height: number } {
     switch (type) {
         case NodeType.NOTE:

--- a/frontend/src/app/visual-programming/core/helpers/segment-avoidance.helper.spec.ts
+++ b/frontend/src/app/visual-programming/core/helpers/segment-avoidance.helper.spec.ts
@@ -143,6 +143,103 @@ describe('computeSegmentAvoidanceWaypoints', () => {
         expect(pathSelfIntersects(fullPath)).toBe(false);
     });
 
+    it("does not force a large overhead detour when the default midpoint only grazes the source node's collision padding, not its actual body", () => {
+        const source = node('source', 260, -200, 330, 60, [{ id: 'source_out', position: 'right' }]);
+        const target = node('target', 600, -80, 330, 60, [{ id: 'target_in', position: 'left' }]);
+
+        const connection = {
+            id: 'conn-1',
+            sourceNodeId: 'source',
+            targetNodeId: 'target',
+            sourcePortId: 'source_out',
+            targetPortId: 'target_in',
+        } as unknown as ConnectionModel;
+
+        const waypoints = computeSegmentAvoidanceWaypoints(connection, [source, target], undefined);
+
+        expect(waypoints).not.toBeNull();
+        expect(waypoints).toEqual([]);
+    });
+
+    it('hugs the real blocker instead of sweeping past the source/target tops when a gap already clears them', () => {
+        const source = node('source', 140, 620, 330, 60, [{ id: 'source_out', position: 'right' }]);
+        const target = node('target', 480, 1000, 330, 60, [{ id: 'target_in', position: 'left' }]);
+        const blocker = node('blocker', 280, 880, 330, 60, []);
+
+        const connection = {
+            id: 'conn-1',
+            sourceNodeId: 'source',
+            targetNodeId: 'target',
+            sourcePortId: 'source_out',
+            targetPortId: 'target_in',
+        } as unknown as ConnectionModel;
+
+        const waypoints = computeSegmentAvoidanceWaypoints(connection, [source, blocker, target], undefined);
+
+        expect(waypoints).not.toBeNull();
+        expect(waypoints!.length).toBeGreaterThan(0);
+
+        const jogY = waypoints![1].y;
+        expect(jogY).toBeGreaterThan(710);
+        expect(jogY).toBeLessThan(850);
+
+        const sourcePt = pt(470, 650);
+        const targetPt = pt(480, 1030);
+        const fullPath = [sourcePt, ...(waypoints ?? []), targetPt];
+        expect(pathSelfIntersects(fullPath)).toBe(false);
+    });
+
+    it('falls back to full clearance instead of the tight jog when the gap next to source/target is too small', () => {
+        const source = node('source', 100, 100, 330, 60, [{ id: 'source_out', position: 'right' }]);
+        const blocker = node('blocker', 250, 170, 330, 400);
+        const target = node('target', 250, 620, 330, 60, [{ id: 'target_in', position: 'left' }]);
+
+        const connection = {
+            id: 'conn-1',
+            sourceNodeId: 'source',
+            targetNodeId: 'target',
+            sourcePortId: 'source_out',
+            targetPortId: 'target_in',
+        } as unknown as ConnectionModel;
+
+        const waypoints = computeSegmentAvoidanceWaypoints(connection, [source, blocker, target], undefined);
+
+        expect(waypoints).not.toBeNull();
+
+        const sourcePt = pt(430, 130);
+        const targetPt = pt(250, 650);
+        const fullPath = [sourcePt, ...(waypoints ?? []), targetPt];
+        expect(pathSelfIntersects(fullPath)).toBe(false);
+    });
+
+    it('still clears all nodes when a second, unrelated node also occupies the tight gap the jog would otherwise use', () => {
+        const source = node('source', 140, 620, 330, 60, [{ id: 'source_out', position: 'right' }]);
+        const target = node('target', 480, 1000, 330, 60, [{ id: 'target_in', position: 'left' }]);
+        const blocker = node('blocker', 280, 880, 330, 60);
+        const secondBlocker = node('second', 280, 760, 330, 40);
+
+        const connection = {
+            id: 'conn-1',
+            sourceNodeId: 'source',
+            targetNodeId: 'target',
+            sourcePortId: 'source_out',
+            targetPortId: 'target_in',
+        } as unknown as ConnectionModel;
+
+        const waypoints = computeSegmentAvoidanceWaypoints(
+            connection,
+            [source, target, blocker, secondBlocker],
+            undefined
+        );
+
+        expect(waypoints).not.toBeNull();
+
+        const sourcePt = pt(470, 650);
+        const targetPt = pt(480, 1030);
+        const fullPath = [sourcePt, ...(waypoints ?? []), targetPt];
+        expect(pathSelfIntersects(fullPath)).toBe(false);
+    });
+
     it('returns an empty array (not null) when no existing waypoints are given and the default route is already clean', () => {
         const source = node('source', 0, 0, 100, 60, [{ id: 'source_out-right', position: 'right' }]);
         const target = node('target', 300, 200, 100, 60, [{ id: 'target_in-left', position: 'left' }]);

--- a/frontend/src/app/visual-programming/core/helpers/segment-avoidance.helper.spec.ts
+++ b/frontend/src/app/visual-programming/core/helpers/segment-avoidance.helper.spec.ts
@@ -1,0 +1,210 @@
+import { IPoint } from '@foblex/2d';
+
+import { NodeType } from '../enums/node-type';
+import { ConnectionModel } from '../models/connection.model';
+import { NodeModel } from '../models/node.model';
+import { computeSegmentAvoidanceWaypoints, pathSelfIntersects } from './segment-avoidance.helper';
+
+function pt(x: number, y: number): IPoint {
+    return { x, y };
+}
+
+function node(
+    id: string,
+    x: number,
+    y: number,
+    width: number,
+    height: number,
+    ports: { id: string; position: string }[] = []
+): NodeModel {
+    return {
+        id,
+        type: NodeType.AGENT,
+        position: { x, y },
+        size: { width, height },
+        ports,
+        data: null,
+    } as unknown as NodeModel;
+}
+
+describe('pathSelfIntersects', () => {
+    it('detects a self-crossing 4-point path (bowtie)', () => {
+        const path = [pt(0, 0), pt(10, 10), pt(10, 0), pt(0, 10)];
+
+        expect(pathSelfIntersects(path)).toBe(true);
+    });
+
+    it('accepts a normal orthogonal zigzag with no self-crossing', () => {
+        const path = [pt(0, 0), pt(0, 10), pt(20, 10), pt(20, 20)];
+
+        expect(pathSelfIntersects(path)).toBe(false);
+    });
+
+    it('flags a path whose later segment doubles back onto an earlier one', () => {
+        const path = [pt(0, 0), pt(20, 0), pt(20, 10), pt(5, 0)];
+
+        expect(pathSelfIntersects(path)).toBe(true);
+    });
+
+    it('does not flag two adjacent segments sharing an endpoint', () => {
+        const path = [pt(0, 0), pt(10, 0), pt(10, 10)];
+
+        expect(pathSelfIntersects(path)).toBe(false);
+    });
+});
+
+describe('computeSegmentAvoidanceWaypoints', () => {
+    it('never returns a self-crossing path when detouring around a blocking node', () => {
+        const source = node('source', 0, 0, 100, 60, [{ id: 'source_out-right', position: 'right' }]);
+        const target = node('target', 400, 200, 100, 60, [{ id: 'target_in-left', position: 'left' }]);
+        const blocker = node('blocker', 200, -50, 100, 340);
+
+        const connection = {
+            id: 'conn-1',
+            sourceNodeId: 'source',
+            targetNodeId: 'target',
+            sourcePortId: 'source_out-right',
+            targetPortId: 'target_in-left',
+        } as unknown as ConnectionModel;
+
+        const waypoints = computeSegmentAvoidanceWaypoints(connection, [source, target, blocker]);
+
+        expect(waypoints).not.toBeNull();
+
+        const sourcePt = pt(100, 30);
+        const targetPt = pt(400, 230);
+        const fullPath = [sourcePt, ...(waypoints ?? []), targetPt];
+
+        expect(pathSelfIntersects(fullPath)).toBe(false);
+    });
+
+    it('never routes the exit/entry stub backward through the source or target node itself', () => {
+        const a = node('a', 110, 275, 240, 45, [{ id: 'a_out', position: 'right' }]);
+        const b = node('b', 120, 340, 230, 45, [
+            { id: 'b_out', position: 'right' },
+            { id: 'b_in', position: 'left' },
+        ]);
+        const c = node('c', 185, 405, 230, 45, [{ id: 'c_in', position: 'left' }]);
+
+        const connection = {
+            id: 'conn-1',
+            sourceNodeId: 'a',
+            targetNodeId: 'c',
+            sourcePortId: 'a_out',
+            targetPortId: 'c_in',
+        } as unknown as ConnectionModel;
+
+        const waypoints = computeSegmentAvoidanceWaypoints(connection, [a, b, c]);
+
+        expect(waypoints).not.toBeNull();
+        expect(waypoints!.length).toBeGreaterThan(0);
+
+        const sourcePt = pt(350, 297.5);
+        const targetPt = pt(185, 427.5);
+
+        expect(waypoints![0].x).toBeGreaterThanOrEqual(sourcePt.x);
+        expect(waypoints![waypoints!.length - 1].x).toBeLessThanOrEqual(targetPt.x);
+
+        const fullPath = [sourcePt, ...(waypoints ?? []), targetPt];
+        expect(pathSelfIntersects(fullPath)).toBe(false);
+    });
+
+    it('routes over the top of the source node when a right-port source sits directly above a west-of-it left-port target, even with no third-node blocker in between', () => {
+        const source = node('source', 100, 100, 330, 60, [{ id: 'source_out', position: 'right' }]);
+        const target = node('target', 100, 240, 330, 60, [{ id: 'target_in', position: 'left' }]);
+
+        const connection = {
+            id: 'conn-1',
+            sourceNodeId: 'source',
+            targetNodeId: 'target',
+            sourcePortId: 'source_out',
+            targetPortId: 'target_in',
+        } as unknown as ConnectionModel;
+
+        const waypoints = computeSegmentAvoidanceWaypoints(connection, [source, target]);
+
+        expect(waypoints).not.toBeNull();
+        expect(waypoints!.length).toBeGreaterThan(0);
+
+        const sourcePt = pt(430, 130);
+        const targetPt = pt(100, 270);
+        const fullPath = [sourcePt, ...(waypoints ?? []), targetPt];
+
+        const cutsThroughSource = fullPath.some(
+            (p, i) =>
+                i < fullPath.length - 1 &&
+                fullPath[i].y === fullPath[i + 1].y &&
+                fullPath[i].y >= 100 &&
+                fullPath[i].y <= 160 &&
+                Math.min(fullPath[i].x, fullPath[i + 1].x) < 430 &&
+                Math.max(fullPath[i].x, fullPath[i + 1].x) > 100
+        );
+        expect(cutsThroughSource).toBe(false);
+        expect(pathSelfIntersects(fullPath)).toBe(false);
+    });
+
+    it('returns an empty array (not null) when no existing waypoints are given and the default route is already clean', () => {
+        const source = node('source', 0, 0, 100, 60, [{ id: 'source_out-right', position: 'right' }]);
+        const target = node('target', 300, 200, 100, 60, [{ id: 'target_in-left', position: 'left' }]);
+
+        const connection = {
+            id: 'conn-1',
+            sourceNodeId: 'source',
+            targetNodeId: 'target',
+            sourcePortId: 'source_out-right',
+            targetPortId: 'target_in-left',
+        } as unknown as ConnectionModel;
+
+        const waypoints = computeSegmentAvoidanceWaypoints(connection, [source, target], undefined);
+
+        expect(waypoints).not.toBeNull();
+        expect(waypoints).toEqual([]);
+    });
+
+    it('returns the clean default path even when an unrelated node is merely near (not actually crossing) it', () => {
+        const source = node('source', 100, 100, 330, 60, [{ id: 'source_out', position: 'right' }]);
+        const stacked = node('stacked', 100, 220, 330, 60, []);
+        const target = node('target', 500, 145, 330, 60, [{ id: 'target_in', position: 'left' }]);
+
+        const connection = {
+            id: 'conn-1',
+            sourceNodeId: 'source',
+            targetNodeId: 'target',
+            sourcePortId: 'source_out',
+            targetPortId: 'target_in',
+        } as unknown as ConnectionModel;
+
+        const waypoints = computeSegmentAvoidanceWaypoints(connection, [source, stacked, target], undefined);
+
+        expect(waypoints).not.toBeNull();
+        expect(waypoints).toEqual([]);
+    });
+
+    it('simplifies a stale reused "box" detour back to the clean default path once it is no longer needed', () => {
+        const source = node('source', 100, 260, 330, 60, [{ id: 'source_out', position: 'right' }]);
+        const nearby = node('nearby', 100, 380, 330, 60, []);
+        const target = node('target', 500, 330, 330, 60, [{ id: 'target_in', position: 'left' }]);
+
+        const connection = {
+            id: 'conn-1',
+            sourceNodeId: 'source',
+            targetNodeId: 'target',
+            sourcePortId: 'source_out',
+            targetPortId: 'target_in',
+        } as unknown as ConnectionModel;
+
+        const staleBoxWaypoints: IPoint[] = [
+            pt(460, 280),
+            pt(460, 180),
+            pt(560, 180),
+            pt(560, 280),
+            pt(480, 280),
+            pt(480, 340),
+        ];
+
+        const waypoints = computeSegmentAvoidanceWaypoints(connection, [source, nearby, target], staleBoxWaypoints);
+
+        expect(waypoints).not.toBeNull();
+        expect(waypoints).toEqual([]);
+    });
+});

--- a/frontend/src/app/visual-programming/core/helpers/segment-avoidance.helper.ts
+++ b/frontend/src/app/visual-programming/core/helpers/segment-avoidance.helper.ts
@@ -13,7 +13,6 @@ const ROUTING_PAD = 15;
 const TABLE_TOP_CLEARANCE = 68;
 const TABLE_TARGET_ENTRY_PAD = 10;
 const SOURCE_EXIT_CLEARANCE = 40;
-const NODE_CLEARANCE = 24;
 
 function getNodeRect(node: NodeModel) {
     const b = getCollisionBounds(node);
@@ -174,6 +173,18 @@ function pathIntersectsNode(path: IPoint[], node: NodeModel): boolean {
     return false;
 }
 
+export function pathSelfIntersects(path: IPoint[]): boolean {
+    for (let i = 0; i < path.length - 1; i++) {
+        for (let j = i + 2; j < path.length - 1; j++) {
+            if (segmentsIntersect(path[i], path[i + 1], path[j], path[j + 1])) {
+                return true;
+            }
+        }
+    }
+
+    return false;
+}
+
 function simplifyRoute(points: IPoint[]): IPoint[] {
     if (points.length <= 2) return points;
 
@@ -206,35 +217,6 @@ function findSegmentBlockers(a: IPoint, b: IPoint, allNodes: NodeModel[], exclud
         const rect = getNodeRect(node);
 
         if (segmentIntersectsRect(a, b, rect)) {
-            result.push(node);
-        }
-    }
-
-    return result;
-}
-
-function findSegmentNearBlockers(
-    a: IPoint,
-    b: IPoint,
-    allNodes: NodeModel[],
-    excludeIds: string[],
-    clearance: number
-): NodeModel[] {
-    const result: NodeModel[] = [];
-
-    for (const node of allNodes) {
-        if (excludeIds.includes(node.id)) continue;
-        if (node.type === NodeType.NOTE) continue;
-
-        const r = getNodeRect(node);
-        const expanded = {
-            nLeft: r.nLeft - clearance,
-            nTop: r.nTop - clearance,
-            nRight: r.nRight + clearance,
-            nBottom: r.nBottom + clearance,
-        };
-
-        if (segmentIntersectsRect(a, b, expanded)) {
             result.push(node);
         }
     }
@@ -456,11 +438,14 @@ function buildForwardVerticalStackRoute(
         return rect.nLeft < defaultMidX && rect.nRight > defaultMidX && rect.nTop < yb && rect.nBottom > ya;
     });
 
-    if (blockers.length === 0) {
+    const defaultMidXCrossesSource = defaultMidX > sourceRect.nLeft && defaultMidX < sourceRect.nRight;
+
+    if (blockers.length === 0 && !defaultMidXCrossesSource) {
         return null;
     }
 
-    const blockerTop = Math.min(...blockers.map((node) => getNodeRect(node).nTop));
+    const blockerTop =
+        blockers.length > 0 ? Math.min(...blockers.map((node) => getNodeRect(node).nTop)) : sourceRect.nTop;
     const exitX = sourceRect.nRight + GAP;
     const entryX = targetRect.nLeft - GAP;
     const routeY = Math.min(sourceRect.nTop, blockerTop) - GAP;
@@ -559,7 +544,7 @@ export function computeSegmentAvoidanceWaypoints(
             if (a.x !== b.x) continue;
             if (a.y === b.y) continue;
 
-            const dropStartsTooCloseToSource = a.x < sourceRect.nRight + SOURCE_EXIT_CLEARANCE;
+            const dropStartsTooCloseToSource = a.x >= sourcePt.x && a.x < sourceRect.nRight + SOURCE_EXIT_CLEARANCE;
 
             const goesBelowOutputLevel = Math.max(a.y, b.y) > sourcePt.y;
 
@@ -568,6 +553,26 @@ export function computeSegmentAvoidanceWaypoints(
             }
 
             return true;
+        }
+
+        return true;
+    };
+
+    const isExitEntryDirectionSafe = (points: IPoint[]): boolean => {
+        if (points.length < 2) return true;
+
+        const first = points[0];
+        const second = points[1];
+        if (first.y === second.y) {
+            if (sourcePort?.position === 'right' && second.x < first.x) return false;
+            if (sourcePort?.position === 'left' && second.x > first.x) return false;
+        }
+
+        const last = points[points.length - 1];
+        const secondLast = points[points.length - 2];
+        if (last.y === secondLast.y) {
+            if (targetPort?.position === 'right' && secondLast.x < last.x) return false;
+            if (targetPort?.position === 'left' && secondLast.x > last.x) return false;
         }
 
         return true;
@@ -662,12 +667,7 @@ export function computeSegmentAvoidanceWaypoints(
 
     const startScore = countPathIntersections(scoreBasePath, allNodes, excludeIds);
 
-    const startHasNearBlockers = scoreBasePath.some((_, idx, arr) => {
-        if (idx === arr.length - 1) return false;
-        return findSegmentNearBlockers(arr[idx], arr[idx + 1], allNodes, excludeIds, NODE_CLEARANCE).length > 0;
-    });
-
-    if (startScore === 0 && !startHasNearBlockers) {
+    if (startScore === 0) {
         if (existingWaypoints && existingWaypoints.length > 0) {
             const defaultPath = simplifyRoute([
                 sourcePt,
@@ -682,7 +682,7 @@ export function computeSegmentAvoidanceWaypoints(
             }
             return null;
         }
-        return null;
+        return [];
     }
 
     let path: IPoint[];
@@ -738,10 +738,14 @@ export function computeSegmentAvoidanceWaypoints(
                     ]);
                     const rebuiltScore = countPathIntersections(rebuilt, allNodes, excludeIds);
 
-                    const minX = Math.min(sourcePt.x, targetPt.x) - corridorPad;
-                    const maxX = Math.max(sourcePt.x, targetPt.x) + corridorPad;
-
-                    if (rebuiltScore === 0 && newMidX >= minX && newMidX <= maxX) {
+                    if (
+                        rebuiltScore === 0 &&
+                        !pathSelfIntersects(rebuilt) &&
+                        isSourceExitSafe(rebuilt) &&
+                        isSourceTableTopSafe(rebuilt) &&
+                        isTableTargetTopSafe(rebuilt) &&
+                        isExitEntryDirectionSafe(rebuilt)
+                    ) {
                         path = rebuilt;
                         changed = true;
                         hadDetour = true;
@@ -762,20 +766,23 @@ export function computeSegmentAvoidanceWaypoints(
                     if (x2Adj > br.nLeft && x2Adj < br.nRight) x2Adj = br.nLeft - corridorPad;
 
                     if (x1Adj !== x2Adj) {
+                        const routeAboveY = Math.min(br.nTop, sourceRect.nTop, targetRect.nTop) - GAP;
+                        const routeBelowY = Math.max(br.nBottom, sourceRect.nBottom, targetRect.nBottom) + GAP;
+
                         const sixPtCandidates = [
                             simplifyRoute([
                                 sourcePt,
                                 { x: x1Adj, y: sourcePt.y },
-                                { x: x1Adj, y: br.nTop - GAP },
-                                { x: x2Adj, y: br.nTop - GAP },
+                                { x: x1Adj, y: routeAboveY },
+                                { x: x2Adj, y: routeAboveY },
                                 { x: x2Adj, y: targetPt.y },
                                 targetPt,
                             ]),
                             simplifyRoute([
                                 sourcePt,
                                 { x: x1Adj, y: sourcePt.y },
-                                { x: x1Adj, y: br.nBottom + GAP },
-                                { x: x2Adj, y: br.nBottom + GAP },
+                                { x: x1Adj, y: routeBelowY },
+                                { x: x2Adj, y: routeBelowY },
                                 { x: x2Adj, y: targetPt.y },
                                 targetPt,
                             ]),
@@ -784,7 +791,11 @@ export function computeSegmentAvoidanceWaypoints(
                         for (const candidate6 of sixPtCandidates) {
                             const rebuiltScore = countPathIntersections(candidate6, allNodes, excludeIds);
 
-                            if (rebuiltScore === 0) {
+                            if (
+                                rebuiltScore === 0 &&
+                                !pathSelfIntersects(candidate6) &&
+                                isExitEntryDirectionSafe(candidate6)
+                            ) {
                                 path = candidate6;
                                 changed = true;
                                 hadDetour = true;
@@ -804,7 +815,7 @@ export function computeSegmentAvoidanceWaypoints(
     }
 
     if (!hadDetour) {
-        return null;
+        return startScore === 0 ? [] : null;
     }
 
     const interiorWaypoints = path.slice(1, -1);
@@ -832,7 +843,14 @@ export function computeSegmentAvoidanceWaypoints(
     const second = interiorWaypoints[0];
     const penultimate = interiorWaypoints[interiorWaypoints.length - 1];
 
-    if (finalScore === 0 && tableTargetTopSafe && sourceExitSafe && sourceTableTopSafe) {
+    if (
+        finalScore === 0 &&
+        tableTargetTopSafe &&
+        sourceExitSafe &&
+        sourceTableTopSafe &&
+        !pathSelfIntersects(fullPath) &&
+        isExitEntryDirectionSafe(fullPath)
+    ) {
         if (interiorWaypoints.length > 0) {
             if (penultimate.y === targetPt.y) {
                 const targetIsLeftPort = targetPort?.position !== 'right';

--- a/frontend/src/app/visual-programming/core/helpers/segment-avoidance.helper.ts
+++ b/frontend/src/app/visual-programming/core/helpers/segment-avoidance.helper.ts
@@ -438,7 +438,8 @@ function buildForwardVerticalStackRoute(
         return rect.nLeft < defaultMidX && rect.nRight > defaultMidX && rect.nTop < yb && rect.nBottom > ya;
     });
 
-    const defaultMidXCrossesSource = defaultMidX > sourceRect.nLeft && defaultMidX < sourceRect.nRight;
+    const defaultMidXCrossesSource =
+        defaultMidX > sourceNode.position.x && defaultMidX < sourceNode.position.x + sourceNode.size.width;
 
     if (blockers.length === 0 && !defaultMidXCrossesSource) {
         return null;
@@ -766,8 +767,20 @@ export function computeSegmentAvoidanceWaypoints(
                     if (x2Adj > br.nLeft && x2Adj < br.nRight) x2Adj = br.nLeft - corridorPad;
 
                     if (x1Adj !== x2Adj) {
-                        const routeAboveY = Math.min(br.nTop, sourceRect.nTop, targetRect.nTop) - GAP;
-                        const routeBelowY = Math.max(br.nBottom, sourceRect.nBottom, targetRect.nBottom) + GAP;
+                        const clearsRectY = (y: number, rect: { nTop: number; nBottom: number }): boolean =>
+                            y <= rect.nTop || y >= rect.nBottom;
+
+                        const tightAboveY = br.nTop - GAP;
+                        const routeAboveY =
+                            clearsRectY(tightAboveY, sourceRect) && clearsRectY(tightAboveY, targetRect)
+                                ? tightAboveY
+                                : Math.min(br.nTop, sourceRect.nTop, targetRect.nTop) - GAP;
+
+                        const tightBelowY = br.nBottom + GAP;
+                        const routeBelowY =
+                            clearsRectY(tightBelowY, sourceRect) && clearsRectY(tightBelowY, targetRect)
+                                ? tightBelowY
+                                : Math.max(br.nBottom, sourceRect.nBottom, targetRect.nBottom) + GAP;
 
                         const sixPtCandidates = [
                             simplifyRoute([

--- a/frontend/src/app/visual-programming/flow-graph/flow-graph.component.html
+++ b/frontend/src/app/visual-programming/flow-graph/flow-graph.component.html
@@ -318,7 +318,7 @@
             </button>
         </div>
     </div>
-    <app-flow-action-panel (undoRedoPerformed)="hasUnarrangedChanges.set(true)"></app-flow-action-panel>
+    <app-flow-action-panel (undoRedoPerformed)="onUndoRedoPerformed()"></app-flow-action-panel>
 
     @if (showContextMenu()) {
         <app-flow-graph-context-menu

--- a/frontend/src/app/visual-programming/flow-graph/flow-graph.component.ts
+++ b/frontend/src/app/visual-programming/flow-graph/flow-graph.component.ts
@@ -231,6 +231,18 @@ export class FlowGraphComponent implements OnInit, OnChanges, OnDestroy {
         return ids;
     });
 
+    protected readonly frozenConnectionIds = computed<Set<string>>(() => {
+        const ids = new Set<string>();
+
+        for (const conn of this.flowService.connections()) {
+            if (conn.userAdjustedWaypoints) {
+                ids.add(conn.id);
+            }
+        }
+
+        return ids;
+    });
+
     protected readonly sortedConnections = computed(() => {
         const backwardIds = this.backwardConnectionIds();
         const hiddenIds = this.hiddenConnectionIds();
@@ -259,7 +271,6 @@ export class FlowGraphComponent implements OnInit, OnChanges, OnDestroy {
     private _importPositionSnapshot: Map<number, { x: number; y: number }> | null = null;
 
     private readonly destroy$ = new Subject<void>();
-    private readonly userAdjustedConnectionIds = new Set<string>();
     private readonly previousBackwardConnectionIds = new Set<string>();
     private draggedNodeIds = new Set<string>();
     private draggingElements = new Set<string>();
@@ -498,7 +509,10 @@ export class FlowGraphComponent implements OnInit, OnChanges, OnDestroy {
         const newConnectionIds = newConnections.map((conn) => conn.id);
 
         setTimeout(() => {
+            this.rerouteSegmentConnections();
             this.fFlowComponent.select(newNodeIds, newConnectionIds);
+            this.cd.detectChanges();
+            this.fFlowComponent?.redraw();
         }, 0);
     }
 
@@ -509,6 +523,7 @@ export class FlowGraphComponent implements OnInit, OnChanges, OnDestroy {
 
         this.hasUnarrangedChanges.set(true);
         this.undoRedoService.onUndo();
+        this.rerouteSegmentConnections();
     }
 
     public onRedo(): void {
@@ -518,6 +533,12 @@ export class FlowGraphComponent implements OnInit, OnChanges, OnDestroy {
 
         this.hasUnarrangedChanges.set(true);
         this.undoRedoService.onRedo();
+        this.rerouteSegmentConnections();
+    }
+
+    protected onUndoRedoPerformed(): void {
+        this.hasUnarrangedChanges.set(true);
+        this.rerouteSegmentConnections();
     }
 
     public onDelete(): void {
@@ -561,18 +582,11 @@ export class FlowGraphComponent implements OnInit, OnChanges, OnDestroy {
 
         const existingCount = connection.waypoints?.length ?? 0;
         if (waypoints.length > existingCount) {
-            this.userAdjustedConnectionIds.add(connectionId);
             this.flowService.updateConnectionWaypoints(connectionId, waypoints, true);
             return;
         }
 
         const normalizedWaypoints = this.normalizeWaypointsForConnection(connection, waypoints);
-
-        if (normalizedWaypoints.length > 0) {
-            this.userAdjustedConnectionIds.add(connectionId);
-        } else {
-            this.userAdjustedConnectionIds.delete(connectionId);
-        }
 
         const isSameElements =
             normalizedWaypoints.length === waypoints.length && normalizedWaypoints.every((p, i) => p === waypoints[i]);
@@ -604,6 +618,12 @@ export class FlowGraphComponent implements OnInit, OnChanges, OnDestroy {
             ),
         };
         this.flowService.updateNode(updatedNode);
+
+        setTimeout(() => {
+            this.rerouteSegmentConnections();
+            this.cd.detectChanges();
+            this.fFlowComponent?.redraw();
+        }, 0);
     }
 
     public onContextMenu(event: MouseEvent): void {
@@ -634,7 +654,18 @@ export class FlowGraphComponent implements OnInit, OnChanges, OnDestroy {
             PointExtensions.initialize(this.contextMenuPosition().x, this.contextMenuPosition().y)
         );
         const newNode = this.nodeFactory.createNode(event.type, { ...event.overrides, position });
-        this.flowService.addNode(newNode);
+        const safePosition = this.findNearestFreePosition(
+            { x: this.snapToGrid(position.x), y: this.snapToGrid(position.y) },
+            this.getCollisionBounds(newNode),
+            this.flowService.nodes()
+        );
+        this.flowService.addNode({ ...newNode, position: safePosition });
+
+        setTimeout(() => {
+            this.rerouteSegmentConnections();
+            this.cd.detectChanges();
+            this.fFlowComponent?.redraw();
+        }, 0);
     }
 
     public onOpenNodePanel(node: NodeModel): void {
@@ -817,9 +848,12 @@ export class FlowGraphComponent implements OnInit, OnChanges, OnDestroy {
             const wasBackward = this.previousBackwardConnectionIds.has(conn.id);
             const isBackward = backwardIds.has(conn.id);
             const changedFromBackwardToForward = wasBackward && !isBackward;
+            const changedFromForwardToBackward = !wasBackward && isBackward;
+            const classificationFlipped = changedFromBackwardToForward || changedFromForwardToBackward;
+            const wasFrozen = this.frozenConnectionIds().has(conn.id);
 
             if (isBackward) {
-                if (this.userAdjustedConnectionIds.has(conn.id)) continue;
+                if (wasFrozen && !classificationFlipped) continue;
 
                 const bwSource = nodes.find((n) => n.id === conn.sourceNodeId);
                 const bwTarget = nodes.find((n) => n.id === conn.targetNodeId);
@@ -844,14 +878,14 @@ export class FlowGraphComponent implements OnInit, OnChanges, OnDestroy {
                     Math.abs(existing.x - newWaypoint.x) > 0.5;
 
                 if (changed) {
-                    this.flowService.updateConnectionWaypoints(conn.id, [newWaypoint]);
+                    this.flowService.updateConnectionWaypoints(conn.id, [newWaypoint], wasFrozen ? false : undefined);
                     this.bumpConnectionRenderVersion(conn.id);
                 }
 
                 continue;
             }
 
-            if (this.userAdjustedConnectionIds.has(conn.id)) continue;
+            if (wasFrozen && !classificationFlipped) continue;
 
             const MAX_ATTEMPTS = 3;
             let current = this.flowService.connections().find((c) => c.id === conn.id);
@@ -890,13 +924,22 @@ export class FlowGraphComponent implements OnInit, OnChanges, OnDestroy {
                     const normalizedRestore = this.normalizeWaypointsForConnection(currentConnection, restoreResult);
 
                     if (!waypointsEqual(currentConnection.waypoints ?? [], normalizedRestore)) {
-                        this.flowService.updateConnectionWaypoints(currentConnection.id, normalizedRestore);
+                        this.flowService.updateConnectionWaypoints(
+                            currentConnection.id,
+                            normalizedRestore,
+                            wasFrozen ? false : undefined
+                        );
                         this.bumpConnectionRenderVersion(currentConnection.id);
                     }
+                } else if (changedFromBackwardToForward && (currentConnection.waypoints?.length ?? 0) > 0) {
+                    this.flowService.updateConnectionWaypoints(currentConnection.id, [], wasFrozen ? false : undefined);
+                    this.bumpConnectionRenderVersion(currentConnection.id);
                 }
 
                 continue;
             }
+
+            let clearedStaleFlipWaypoint = false;
 
             for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
                 const waypoints = computeSegmentAvoidanceWaypoints(
@@ -905,14 +948,29 @@ export class FlowGraphComponent implements OnInit, OnChanges, OnDestroy {
                     changedFromBackwardToForward ? undefined : current.waypoints
                 );
 
-                if (waypoints === null) break;
+                if (waypoints === null) {
+                    if (
+                        changedFromBackwardToForward &&
+                        !clearedStaleFlipWaypoint &&
+                        (current.waypoints?.length ?? 0) > 0
+                    ) {
+                        this.flowService.updateConnectionWaypoints(current.id, [], wasFrozen ? false : undefined);
+                        this.bumpConnectionRenderVersion(current.id);
+                    }
+                    break;
+                }
 
                 const normalizedWaypoints = this.normalizeWaypointsForConnection(current, waypoints);
                 if (waypointsEqual(current.waypoints ?? [], normalizedWaypoints)) break;
 
-                this.flowService.updateConnectionWaypoints(current.id, normalizedWaypoints);
+                this.flowService.updateConnectionWaypoints(
+                    current.id,
+                    normalizedWaypoints,
+                    wasFrozen ? false : undefined
+                );
                 this.bumpConnectionRenderVersion(current.id);
                 current = { ...current, waypoints: normalizedWaypoints };
+                clearedStaleFlipWaypoint = true;
             }
         }
 
@@ -1046,14 +1104,12 @@ export class FlowGraphComponent implements OnInit, OnChanges, OnDestroy {
 
         // Pre-identify non-user-adjusted backward connections for per-frame arc updates.
         const backwardIds = this.backwardConnectionIds();
-        const backwardConns = connections.filter(
-            (c) => backwardIds.has(c.id) && !this.userAdjustedConnectionIds.has(c.id)
-        );
+        const backwardConns = connections.filter((c) => backwardIds.has(c.id) && !c.userAdjustedWaypoints);
 
         // Clear ALL non-user-adjusted waypoints (including backward) so every connection
         // starts from a clean state. Backward arcs are re-computed each frame below.
         for (const conn of connections) {
-            if (conn.waypoints?.length && !this.userAdjustedConnectionIds.has(conn.id)) {
+            if (conn.waypoints?.length && !conn.userAdjustedWaypoints) {
                 this.flowService.updateConnectionWaypoints(conn.id, []);
             }
         }
@@ -1121,7 +1177,7 @@ export class FlowGraphComponent implements OnInit, OnChanges, OnDestroy {
                     const finalConnections = this.flowService.connections();
                     const bwIds = this.backwardConnectionIds();
                     for (const conn of finalConnections) {
-                        if (!bwIds.has(conn.id) || this.userAdjustedConnectionIds.has(conn.id)) continue;
+                        if (!bwIds.has(conn.id) || conn.userAdjustedWaypoints) continue;
                         const src = finalNodes.find((n) => n.id === conn.sourceNodeId);
                         const tgt = finalNodes.find((n) => n.id === conn.targetNodeId);
                         if (!src || !tgt) continue;
@@ -1511,13 +1567,7 @@ export class FlowGraphComponent implements OnInit, OnChanges, OnDestroy {
     private applyIncomingFlowState(flowState: FlowModel): void {
         const normalizedFlowState = normalizeFlowPorts(flowState);
         this.flowService.setFlow(normalizedFlowState);
-        for (const conn of normalizedFlowState.connections) {
-            if (conn.userAdjustedWaypoints) {
-                this.userAdjustedConnectionIds.add(conn.id);
-            } else {
-                this.userAdjustedConnectionIds.delete(conn.id);
-            }
-        }
+        this.rerouteSegmentConnections();
     }
 
     private _shiftImportedNodes(flowState: FlowModel, preImportIds: Set<number>): FlowModel {


### PR DESCRIPTION
## Description

Implementation of task [EST-2752](https://hys-enterprise.atlassian.net/browse/EST-2752).
### Resolves two reported connection-routing problems in the flow editor:
1. Connections randomly rendering as visual loops/zigzags
2. Connections sometimes routing under (behind) other nodes
### Root causes & fixes
- **Stale waypoint reuse**: after a node drag, the reroute logic was reusing outdated/overly complex waypoints instead of recomputing a clean path, even when a simple straight line was already available. Fixed the early-return and fallback logic in `computeSegmentAvoidanceWaypoints` to correctly collapse back to a clean route once a detour is no longer needed.
- **Connections cutting through nodes**: a vertical-stack route (right-port source directly above a left-port target) could draw its first leg straight through the source node's own body when no other node was blocking the direct path. Extended `buildForwardVerticalStackRoute` to also route over the top in this case.
- **Classification-flip race with realtime collaboration**: when a connection's backward/forward classification flipped (e.g. after a drag), a WebSocket echo of the flow state could reset the tracking used to detect that flip before the reroute pass had a chance to clean up the old (semantically different) waypoint, permanently stranding a backward-arc "route height" hint as a literal segment bend point. Replaced the silent tracking resync with a full reroute pass so this can no longer race.
- **Classification decision table node overlap**: added correct collision bounds for `CLASSIFICATION_TABLE` nodes so other nodes/connections no longer overlap them.

## Checklist

- [ ] I have signed the **Contributor License Agreement (CLA)**. The CLA bot will comment on this PR — comment `I have read the CLA Document and I hereby sign the CLA` to sign. **This PR cannot be merged until the CLA is signed.**
- [ ] My code follows the project's style and conventions.
- [ ] I have tested my changes.
- [ ] I have updated documentation where needed.
