### PR TITLE
fix/EST-3942 return 404 instead of 500 for Http404 and PermissionDenied

### DIFF
--- a/src/django_app/tests/api_tests/test_exception_handler_http404.py
+++ b/src/django_app/tests/api_tests/test_exception_handler_http404.py
@@ -1,0 +1,47 @@
+import pytest
+from django.core.exceptions import PermissionDenied as DjangoPermissionDenied
+from django.http import Http404
+
+from utils.exception_handler import custom_exception_handler
+
+
+@pytest.fixture(params=[True, False], ids=["debug_on", "debug_off"])
+def any_debug(request, monkeypatch):
+    """Run the test under both `DEBUG` values, since the handler branches on it."""
+    monkeypatch.setattr("utils.exception_handler.DEBUG", request.param)
+    return request.param
+
+
+def test_http404_renders_as_404(any_debug):
+    response = custom_exception_handler(
+        Http404("No Graph matches the given query."), {}
+    )
+
+    assert response.status_code == 404
+    assert response.data["status_code"] == 404
+    assert response.data["code"] == "not_found"
+    assert response.data["message"] == "NotFound: No Graph matches the given query."
+
+
+def test_bare_http404_falls_back_to_default_detail(any_debug):
+    response = custom_exception_handler(Http404(), {})
+
+    assert response.status_code == 404
+    assert response.data["message"] == "NotFound: Not found."
+
+
+def test_django_permission_denied_renders_as_403(any_debug):
+    response = custom_exception_handler(DjangoPermissionDenied("Nope."), {})
+
+    assert response.status_code == 403
+    assert response.data["status_code"] == 403
+    assert response.data["message"] == "PermissionDenied: Nope."
+
+
+def test_unknown_exception_still_renders_as_500(monkeypatch):
+    monkeypatch.setattr("utils.exception_handler.DEBUG", False)
+
+    response = custom_exception_handler(RuntimeError("boom"), {})
+
+    assert response.status_code == 500
+    assert b"RuntimeError: Unpredictable error" in response.content

--- a/src/django_app/utils/exception_handler.py
+++ b/src/django_app/utils/exception_handler.py
@@ -1,20 +1,19 @@
-from rest_framework.views import exception_handler
+from django.core.exceptions import PermissionDenied
+from django.http import Http404, JsonResponse
+from rest_framework import exceptions
 from rest_framework.exceptions import APIException
+from rest_framework.views import exception_handler
+
 from django_app.settings import DEBUG
-from django.http import JsonResponse
 
 
 def custom_exception_handler(exc, context):
-    """
-    Custom exception handler for API.
+    """Render every exception as the project's `{status_code, code, message}` envelope."""
 
-    This function handles exceptions raised during the processing of API requests.
-    - If the exception is an instance of `APIException`, it customizes the response data
-      to include `status_code`, `code`, and a detailed error message.
-
-    - If `DEBUG` is enabled, the default behavior of `exception_handler` is used.
-
-    """
+    if isinstance(exc, Http404):
+        exc = exceptions.NotFound(*exc.args)
+    elif isinstance(exc, PermissionDenied):
+        exc = exceptions.PermissionDenied(*exc.args)
 
     response = exception_handler(exc, context)
 


### PR DESCRIPTION
## Description

Every endpoint that raises `Http404` returned `500 Unpredictable error`
instead of `404`:

    GET /api/graphs/999999/
    {"status_code": 500, "code": "Http404", "message": "Http404: Unpredictable error"}

That is every DRF `get_object()` call (all `ModelViewSet`
retrieve/update/destroy), the `get_object_or_404` uses in
`realtime_service.py` and `default_config.py`, and the explicit
`raise Http404` in `flow_assistant_views.py`.

**Only when `DEBUG=False`.** The 500 branch sits behind `if not DEBUG`,
so development returned a correct 404 and hid the bug, while the
production default (`.env.example`, `docker-compose.yaml`'s
`${DEBUG:-False}`) returned 500. This also meant dev and prod answered
the same request with different status codes.

## Checklist

- [ ] I have signed the **Contributor License Agreement (CLA)**. The CLA bot will comment on this PR — comment `I have read the CLA Document and I hereby sign the CLA` to sign. **This PR cannot be merged until the CLA is signed.**
- [ ] My code follows the project's style and conventions.
- [ ] I have tested my changes.
- [ ] I have updated documentation where needed.
