### PR TITLE
fix(EST-3963): store only sha256 of SSE/WS tickets in Redis

### DIFF
--- a/docs/rbac/DEV_rbac_backend_guide.md
+++ b/docs/rbac/DEV_rbac_backend_guide.md
@@ -135,7 +135,8 @@ Two authentication classes (`tables/services/rbac/authentication.py`), both glob
 Connections that cannot carry headers (SSE, WebSocket) use single-use Redis tickets
 (`TicketService`, `tables/services/rbac/ticket_service.py`): `POST /api/auth/sse-ticket/`
 or `/api/auth/ws-ticket/` with JWT → 30 s single-use ticket consumed atomically via
-`GETDEL`, passed as `?ticket=` on the stream URL.
+`GETDEL`, passed as `?ticket=` on the stream URL. Redis stores only
+`sha256(ticket)` as the key, so Redis read access yields no replayable ticket.
 
 Throttling (`tables/throttles.py`) — every anonymous credential-adjacent endpoint is covered:
 

--- a/docs/rbac/auth_endpoints.md
+++ b/docs/rbac/auth_endpoints.md
@@ -322,7 +322,8 @@ See the dedicated [`sse_auth.md`](./sse_auth.md) for the complete FE flow.
   { "ticket": "<opaque random>", "expires_in": 30 }
   ```
 - Tickets are **single-use** and stored in Redis under
-  `rbac:sse_ticket:<token>` keys. TTL is `SSE_TICKET_TTL_SECONDS`
+  `rbac:sse_ticket:<sha256-of-token>` keys — only the digest is persisted,
+  never the ticket itself. TTL is `SSE_TICKET_TTL_SECONDS`
   (hardcoded to 30 seconds in `settings.py`). Consume uses Redis `GETDEL` (6.2+) for
   atomic get-and-delete, so even two simultaneous connects with the same
   ticket cannot both succeed. Reconnects must fetch a fresh ticket.

--- a/docs/rbac/sse_auth.md
+++ b/docs/rbac/sse_auth.md
@@ -2,7 +2,6 @@
 
 **Audience:** frontend developers.
 **Scope:** all `text/event-stream` (SSE) endpoints — `run-session` live stream, filtered external stream, and any future SSE route.
-**Status:** required from the moment Story 2 ships. There is **no backwards compatibility**; old direct-connect URLs without a ticket will receive `401 invalid_sse_ticket`.
 
 ---
 
@@ -131,5 +130,5 @@ The `text/event-stream` handshake never starts when the ticket is rejected; you 
 |---|---|---|
 | `SSE_TICKET_TTL_SECONDS` | `30` (hardcoded in `settings.py`) | How long a freshly issued ticket is valid before consume. |
 
-Tickets are stored in Redis via the raw `django_redis` client under the `rbac:sse_ticket:<token>` key. Consume uses `GETDEL` (Redis 6.2+) so get-and-delete is atomic — two simultaneous consumers cannot both succeed. They are not persisted to the database.
+Tickets are stored in Redis via the raw `django_redis` client under the `rbac:sse_ticket:<sha256-of-token>` key. Redis holds only the SHA-256 digest of the ticket, never the ticket itself, so read access to Redis yields no replayable credential. Consume hashes the incoming ticket and uses `GETDEL` (Redis 6.2+) so get-and-delete is atomic — two simultaneous consumers cannot both succeed. They are not persisted to the database.
 

--- a/src/django_app/tables/services/rbac/ticket_service.py
+++ b/src/django_app/tables/services/rbac/ticket_service.py
@@ -1,8 +1,14 @@
+import hashlib
 import secrets
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django_redis import get_redis_connection
+
+
+def ticket_digest(ticket: str) -> str:
+    """Derive the storage form of a ticket. Pure - no I/O."""
+    return hashlib.sha256(ticket.encode("utf-8")).hexdigest()
 
 
 class TicketService:
@@ -13,9 +19,12 @@ class TicketService:
     The client POSTs with JWT to issue a ticket and then opens the connection
     URL with `?ticket=<value>`. Each ticket is consumed atomically via GETDEL
     (Redis 6.2+) so replay is impossible even under concurrent reconnects.
+
+    Redis holds only the SHA-256 digest of a ticket, never the ticket itself,
+    so read access to Redis yields no replayable credential.
     """
 
-    def __init__(self, prefix: str, ttl_seconds: int):
+    def __init__(self, prefix: str, ttl_seconds: int) -> None:
         self._prefix = prefix
         self._ttl_seconds = ttl_seconds
 
@@ -23,7 +32,7 @@ class TicketService:
         return get_redis_connection("default")
 
     def _key(self, ticket: str) -> str:
-        return f"{self._prefix}{ticket}"
+        return f"{self._prefix}{ticket_digest(ticket)}"
 
     def issue(self, user) -> tuple[str, int]:
         ticket = secrets.token_urlsafe(32)
@@ -31,7 +40,7 @@ class TicketService:
         return ticket, self._ttl_seconds
 
     def consume(self, ticket: str) -> object | None:
-        if not ticket:
+        if not isinstance(ticket, str) or not ticket:
             return None
         raw = self._redis().getdel(self._key(ticket))
         if raw is None:

--- a/src/django_app/tests/api_tests/test_rbac_auth.py
+++ b/src/django_app/tests/api_tests/test_rbac_auth.py
@@ -13,6 +13,7 @@ Integration tests for the Story 2 auth surface:
 - SSE ticket issue/consume single-use + expired + atomic
 """
 
+import hashlib
 import re
 from datetime import timedelta
 from unittest.mock import patch
@@ -23,6 +24,7 @@ from django.contrib.auth import get_user_model
 from django.db import IntegrityError, transaction
 from django.core import mail
 from django.core.cache import cache
+from django_redis import get_redis_connection
 from django.test import override_settings
 from django.urls import reverse
 from django.utils import timezone
@@ -41,7 +43,7 @@ from tables.models.rbac_models import (
 )
 from tables.models.rbac_models.rbac_enums import BuiltInRole
 from tables.services.rbac.reset_user_service import ResetUserService
-from tables.services.rbac.ticket_service import sse_ticket_service
+from tables.services.rbac.ticket_service import sse_ticket_service, ws_ticket_service
 from tables.services.rbac.utils.refresh_cookie import REFRESH_COOKIE_NAME
 from tables.services.rbac.utils.password_reset_token_repository import (
     PasswordResetTokenRepository,
@@ -264,6 +266,47 @@ def test_sse_ticket_expired_or_unknown_returns_none():
 def test_sse_ticket_endpoint_requires_jwt(api_client):
     r = api_client.post(reverse("sse_ticket"))
     assert r.status_code == 401
+
+
+# ---------------- Ticket at rest ----------------
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "service, prefix",
+    [
+        (sse_ticket_service, "rbac:sse_ticket:"),
+        (ws_ticket_service, "rbac:ws_ticket:"),
+    ],
+    ids=["sse", "ws"],
+)
+def test_redis_never_holds_the_raw_ticket(regular_user, service, prefix: str):
+    """Read access to Redis must not yield a replayable ticket.
+
+    The key is the SHA-256 digest of the ticket, so `SCAN MATCH "<prefix>*"`
+    returns digests that cannot be inverted into a usable ticket.
+    """
+    cache.clear()
+    ticket, _ = service.issue(regular_user)
+
+    keys = [key.decode() for key in get_redis_connection("default").keys(f"{prefix}*")]
+    expected = f"{prefix}{hashlib.sha256(ticket.encode('utf-8')).hexdigest()}"
+    assert keys == [expected]
+    assert ticket not in keys[0]
+
+    # The raw ticket still resolves; only its storage form changed.
+    assert service.consume(ticket).pk == regular_user.pk
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "service", [sse_ticket_service, ws_ticket_service], ids=["sse", "ws"]
+)
+def test_consume_rejects_non_string_ticket(service):
+    cache.clear()
+    assert service.consume(None) is None
+    assert service.consume(12345) is None
+    assert service.consume("") is None
 
 
 # ---------------- Logout ownership ----------------
@@ -1137,9 +1180,9 @@ class TestPasswordResetRequestThrottleNonString:
         body = r.json()
         email_errors = [e for e in body["errors"] if e["field"] == "email"]
         assert email_errors
-        assert any("must be a string" in e["reason"].lower() for e in email_errors), (
-            body
-        )
+        assert any(
+            "must be a string" in e["reason"].lower() for e in email_errors
+        ), body
 
 
 # ---------------- Default-org: single-default constraint ----------------


### PR DESCRIPTION
The raw ticket was the Redis key name, so any read access to Redis yielded live, replayable tickets via SCAN MATCH. TicketService._key now hashes it; issue() still returns the raw ticket and consume() re-derives the digest, so the API and single-use GETDEL contract are unchanged. Covers both sse_ticket and ws_ticket.

## Description

<!-- Describe what this PR changes and why. -->

## Checklist

- [x] I have signed the **Contributor License Agreement (CLA)**. The CLA bot will comment on this PR — comment `I have read the CLA Document and I hereby sign the CLA` to sign. **This PR cannot be merged until the CLA is signed.**
- [x] My code follows the project's style and conventions.
- [x] I have tested my changes.
- [x] I have updated documentation where needed.
