### PR TITLE
fix(EST-4054-FE): remove background color from node-type selector

### DIFF
--- a/frontend/src/app/features/configure-models/components/secret-usage-dialog/secret-usage-dialog.component.html
+++ b/frontend/src/app/features/configure-models/components/secret-usage-dialog/secret-usage-dialog.component.html
@@ -120,6 +120,7 @@
                                         [expanded]="isFlowExpanded(flow.name)"
                                         [nodeTypeLabels]="nodeTypeLabels"
                                         [trailingTemplate]="nodeLinkTpl"
+                                        [nodeTypeFilterTransparent]="true"
                                     />
                                     <ng-template
                                         #nodeLinkTpl

--- a/frontend/src/app/shared/components/flow-node-list/flow-node-list.component.html
+++ b/frontend/src/app/shared/components/flow-node-list/flow-node-list.component.html
@@ -14,6 +14,7 @@
                 placeholder="Select Node Type"
                 [items]="nodeTypeFilterItems()"
                 [selectedValue]="nodeTypeFilter()"
+                [transparent]="nodeTypeFilterTransparent()"
                 (changed)="onNodeTypeFilterChange($event)"
             />
         </div>

--- a/frontend/src/app/shared/components/flow-node-list/flow-node-list.component.ts
+++ b/frontend/src/app/shared/components/flow-node-list/flow-node-list.component.ts
@@ -33,6 +33,7 @@ export class FlowNodeListComponent<T extends FlowNodeListItem = FlowNodeListItem
     public readonly nodeTypeLabels = input.required<Partial<Record<NodeType, string>>>();
     public readonly trailingTemplate = input<TemplateRef<{ $implicit: T }> | null>(null);
     public readonly searchPlaceholder = input<string>('Search node...');
+    public readonly nodeTypeFilterTransparent = input<boolean>(false);
 
     public readonly rowClick = output<T>();
 

--- a/frontend/src/app/shared/components/select/select.component.html
+++ b/frontend/src/app/shared/components/select/select.component.html
@@ -17,6 +17,7 @@
             [class.selector__btn--invalid]="invalid()"
             [class.selector__btn--open]="open()"
             [class.selector__btn--placeholder]="!selectedItem()"
+            [class.selector__btn--transparent]="transparent()"
             (click)="toggle()"
         >
             @if (loading()) {

--- a/frontend/src/app/shared/components/select/select.component.scss
+++ b/frontend/src/app/shared/components/select/select.component.scss
@@ -60,6 +60,10 @@
             border-color: var(--color-ks-status-failed);
         }
 
+        &--transparent {
+            background-color: transparent;
+        }
+
         &:disabled {
             cursor: not-allowed;
             opacity: 0.7;

--- a/frontend/src/app/shared/components/select/select.component.ts
+++ b/frontend/src/app/shared/components/select/select.component.ts
@@ -66,6 +66,7 @@ export class SelectComponent implements ControlValueAccessor {
     variant = input<SelectVariant>('default');
     showSearch = input<boolean>(false);
     searchPlaceholder = input<string>('Search...');
+    transparent = input<boolean>(false);
 
     changed = output<unknown>();
     opened = output<void>();


### PR DESCRIPTION
## Description

Implementation of task [EST-4054](https://hys-enterprise.atlassian.net/browse/EST-4054).

The ticket asked to remove the background color from the "Select Node Type" selector in Settings → Secrets Usage.

That selector is app-select, rendered inside the shared app-flow-node-list component, which is also reused by the unrelated import-review-dialog (flow-review-nodes). Changing app-select's default background directly would have affected every other usage of that component across the app, so this needed to be opt-in and scoped to just this one place.

**What was done:**
- app-select: added an opt-in transparent input that drops the trigger button's background color, leaving border/hover/open/disabled states untouched.
- app-flow-node-list: added a nodeTypeFilterTransparent input, threaded to its internal app-select.
- secret-usage-dialog: passes [nodeTypeFilterTransparent]="true", so only the Secrets Usage panel's selector loses its background — flow-review-nodes and every other app-select consumer are unaffected.

## Checklist

- [ ] I have signed the **Contributor License Agreement (CLA)**. The CLA bot will comment on this PR — comment `I have read the CLA Document and I hereby sign the CLA` to sign. **This PR cannot be merged until the CLA is signed.**
- [ ] My code follows the project's style and conventions.
- [ ] I have tested my changes.
- [ ] I have updated documentation where needed.